### PR TITLE
Feature/update vulnerable packages

### DIFF
--- a/Conductor/conductor-csharp.csproj
+++ b/Conductor/conductor-csharp.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
@@ -17,7 +17,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <None Include="/package/Conductor/README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/Conductor/conductor-csharp.csproj
+++ b/Conductor/conductor-csharp.csproj
@@ -9,14 +9,15 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <None Include="/package/Conductor/README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS csharp-sdk
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS csharp-sdk
 RUN mkdir /package
 COPY /Conductor /package/Conductor
 COPY /README.md /package/Conductor/README.md

--- a/Tests/Helper/TestConstants.cs
+++ b/Tests/Helper/TestConstants.cs
@@ -32,5 +32,6 @@ namespace conductor_csharp.test.Helper
         public const string TestAddTask = "Test-add-task";
         public const string BODY = "EnvironmentTestBody";
         public const string KEY = "EnvironmentTestKey";
+        public const string OWNER_EMAIL = "test-sdk-csharp@conductor.com";
     }
 }

--- a/Tests/Worker/AnnotatedWorkerTest.cs
+++ b/Tests/Worker/AnnotatedWorkerTest.cs
@@ -33,6 +33,7 @@ namespace Tests.Worker
         private const string WORKFLOW_NAME = "test-annotation";
         private const int WORKFLOW_VERSION = 1;
         private const string WORKFLOW_DESC = "test-annotation-desc";
+        private const string OWNER_EMAIL = "test-sdk-csharp@conductor.com";
 
         public AnnotatedWorkerTest()
         {
@@ -51,7 +52,7 @@ namespace Tests.Worker
         public void TestAnnotatedMethods()
         {
             var workflow = GetConductorWorkflow();
-            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.QuoteTaskName };
+            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.QuoteTaskName, OwnerEmail = TestConstants.OWNER_EMAIL };
             var getQuoteTask = new SimpleTask(TestConstants.QuoteTaskName, TestConstants.QuoteTaskName);
             getQuoteTask.Description = TestConstants.TaskDescription;
             workflow.WithTask(getQuoteTask);
@@ -63,7 +64,7 @@ namespace Tests.Worker
         public void TestAnnotationWithInputParam()
         {
             var workflow = GetConductorWorkflow();
-            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.InputTaskName };
+            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.InputTaskName, OwnerEmail = TestConstants.OWNER_EMAIL };
             var getInputValue = new SimpleTask(TestConstants.InputTaskName, TestConstants.InputTaskName).WithInput("userId", workflow.Input("userId")).WithInput("otp", workflow.Input("otp"));
             getInputValue.Description = TestConstants.TaskDescription;
             workflow.WithTask(getInputValue);
@@ -80,7 +81,7 @@ namespace Tests.Worker
         public void TestAnnotationWithMultipleInputParam()
         {
             var workflow = GetConductorWorkflow();
-            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.TestAddTask };
+            TaskDef taskDef = new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.TestAddTask, OwnerEmail = TestConstants.OWNER_EMAIL };
             var getSumValue = new SimpleTask(TestConstants.TestAddTask, TestConstants.TestAddTask).WithInput("numberOne", workflow.Input("numberOne")).WithInput("numberTwo", workflow.Input("numberTwo"));
             getSumValue.Description = TestConstants.TaskDescription;
             workflow.WithTask(getSumValue);
@@ -98,8 +99,8 @@ namespace Tests.Worker
         {
             var workflow = GetConductorWorkflow();
             List<TaskDef> taskDefs = new List<TaskDef>() {
-                new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.TestAddTask },
-                new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.InputTaskName }
+                new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.TestAddTask, OwnerEmail = TestConstants.OWNER_EMAIL },
+                new TaskDef() { Description = TestConstants.TaskDescription, Name = TestConstants.InputTaskName, OwnerEmail = TestConstants.OWNER_EMAIL }
             };
             var getInputValue = new SimpleTask(TestConstants.InputTaskName, TestConstants.InputTaskName).WithInput("userId", workflow.Input("userId")).WithInput("otp", workflow.Input("otp"));
             getInputValue.Description = TestConstants.TaskDescription;
@@ -126,7 +127,9 @@ namespace Tests.Worker
             return new ConductorWorkflow()
                 .WithName(WORKFLOW_NAME)
                 .WithVersion(WORKFLOW_VERSION)
-                .WithDescription(WORKFLOW_DESC);
+                .WithDescription(WORKFLOW_DESC)
+                .WithOwner(OWNER_EMAIL);
+
         }
 
         /// <summary>

--- a/Tests/Worker/TestWorkflows.cs
+++ b/Tests/Worker/TestWorkflows.cs
@@ -50,7 +50,8 @@ namespace Test.Worker
             var workflow = new ConductorWorkflow()
             .WithName("unit_testing_example")
             .WithDescription("test unit test")
-            .WithVersion(1);
+            .WithVersion(1)
+            .WithOwner("exampleEmail@conductor.com");
             var task1 = new SimpleTask("hello_C_1", "hello_ref_C_1");
             var task2 = new SimpleTask("hello_C_2", "hello_ref_C_2");
             var task3 = new SimpleTask("hello_C_3", "hello_ref_C_3");

--- a/Tests/Worker/WorkerTests.cs
+++ b/Tests/Worker/WorkerTests.cs
@@ -31,6 +31,7 @@ namespace Tests.Worker
         private const int WORKFLOW_VERSION = 1;
         private const string TASK_NAME = "test-sdk-csharp-task";
         private const string TASK_DOMAIN = "taskDomain";
+        private const string OWNER_EMAIL = "test-sdk-csharp@conductor.com";
 
         private readonly WorkflowResourceApi _workflowClient;
         private readonly ILogger _logger;
@@ -56,7 +57,8 @@ namespace Tests.Worker
             return new ConductorWorkflow()
                 .WithName(WORKFLOW_NAME)
                 .WithVersion(WORKFLOW_VERSION)
-                .WithTask(new SimpleTask(TASK_NAME, TASK_NAME));
+                .WithTask(new SimpleTask(TASK_NAME, TASK_NAME))
+                .WithOwner(OWNER_EMAIL);
         }
 
         private async System.Threading.Tasks.Task<ConcurrentBag<string>> StartWorkflows(ConductorWorkflow workflow, int quantity)

--- a/Tests/conductor-csharp.test.csproj
+++ b/Tests/conductor-csharp.test.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
   </ItemGroup>

--- a/Tests/conductor-csharp.test.csproj
+++ b/Tests/conductor-csharp.test.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
   </ItemGroup>

--- a/csharp-examples/csharp-examples.csproj
+++ b/csharp-examples/csharp-examples.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp-examples/csharp-examples.csproj
+++ b/csharp-examples/csharp-examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>csharp_examples</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
-      Version="1.19.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Vulnerable Packages
Update .Net 8 LTS
Update Unit Tests for required fields that were causing a failure when connecting to conductor.

Main vulnerability looking to resolve is this one in RestSharp: https://nvd.nist.gov/vuln/detail/CVE-2024-45302
Which is consumed by the Conductor-C# Sdk. 

Unit tests have passed.
Those that have failed were targeting unknown endpoints on the conductor-oss image, the /Environment or /Integrations don't seem to exist so would appreciate any advice on that one.

![image](https://github.com/user-attachments/assets/7bc92ecb-15d8-4863-bea2-dbfe35d01770)

Vulnerabilities highlighted:
https://github.com/advisories/GHSA-qj66-m88j-hmgj
https://github.com/advisories/GHSA-4rr6-2v9v-wcpc
https://github.com/advisories/GHSA-7jgj-8wvc-jh57
https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
https://github.com/advisories/GHSA-cmhx-cq75-c4mj

![image](https://github.com/user-attachments/assets/5c2a87e4-0fc0-4998-b5dc-1c60b046cedf)

