### PR TITLE
Use TotalSeconds instead of Seconds when setting WAIT task duration

### DIFF
--- a/Conductor/Definition/TaskType/WaitTask.cs
+++ b/Conductor/Definition/TaskType/WaitTask.cs
@@ -22,7 +22,7 @@ namespace Conductor.Definition.TaskType
 
         public WaitTask(string taskReferenceName, TimeSpan duration) : base(taskReferenceName, WorkflowTask.WorkflowTaskTypeEnum.WAIT)
         {
-            WithInput(DURATION_PARAMETER, duration.Seconds.ToString() + "s");
+            WithInput(DURATION_PARAMETER, duration.TotalSeconds.ToString() + "s");
         }
 
         public WaitTask(string taskReferenceName, DateTime until) : base(taskReferenceName, WorkflowTask.WorkflowTaskTypeEnum.WAIT)


### PR DESCRIPTION
Replaced the use of TimeSpan.Seconds with TimeSpan.TotalSeconds to ensure the WAIT task receives the full duration in seconds rather than only the seconds component of the TimeSpan. This prevents incorrect durations when the TimeSpan spans minutes, hours, or longer intervals.