### PR TITLE
fix: update worker docs link from conductor-sdk to conductor-oss org

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ workflowClient.StartWorkflow(
 )
 ```
 
-### Next: [Create and run task workers](https://github.com/conductor-sdk/conductor-csharp/blob/main/docs/readme/workers.md)
+### Next: [Create and run task workers](https://github.com/conductor-oss/csharp-sdk/blob/main/docs/readme/workers.md)


### PR DESCRIPTION
## Summary

The "Next" link at the bottom of the README pointed to `github.com/conductor-sdk/conductor-csharp` (old org). Update to `github.com/conductor-oss/csharp-sdk` (current repo).

The old link still works via 301 redirect, but it's better to point directly to the correct location.

Closes conductor-oss/getting-started#26 (partially — the link fix; a Hello World section remains a separate, larger task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)