### PR TITLE
docs: add Hello World section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,80 @@ Show support for the Conductor OSS.  Please help spread the awareness by starrin
 dotnet add package conductor-csharp
 ```
 
+## Hello World
+
+This example creates a worker, connects it to a local Conductor server, and runs it end-to-end.
+
+### Step 1: Start a local Conductor server
+
+```shell
+docker run --init -p 8080:8080 conductoross/conductor-standalone:latest
+```
+
+### Step 2: Define and run a worker
+
+```csharp
+using Conductor.Client;
+using Conductor.Client.Extensions;
+using Conductor.Client.Worker;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// Define a worker using the [WorkerTask] attribute
+[WorkerTask]
+public class GreetWorker
+{
+    [WorkerTask(taskType: "greet", batchSize: 1, pollIntervalMs: 200, workerId: "greeter")]
+    public string Greet([InputParam("name")] string name)
+    {
+        return $"Hello, {name}!";
+    }
+}
+
+// Connect to local OSS Conductor and start polling
+var configuration = new Configuration
+{
+    BasePath = "http://localhost:8080/api"
+};
+
+var host = WorkflowTaskHost.CreateWorkerHost(configuration, LogLevel.Information, new GreetWorker());
+await host.StartAsync();
+Console.WriteLine("Worker started. Press Ctrl+C to stop.");
+await Task.Delay(Timeout.Infinite);
+```
+
+### Step 3: Register a workflow and run it
+
+```csharp
+using Conductor.Api;
+using Conductor.Client;
+using Conductor.Definition;
+using Conductor.Definition.TaskType;
+using Conductor.Executor;
+
+var configuration = new Configuration { BasePath = "http://localhost:8080/api" };
+
+// Build and register the workflow
+var workflow = new ConductorWorkflow()
+    .WithName("greetings")
+    .WithVersion(1)
+    .WithTask(new SimpleTask("greet", "greet_ref").WithInput("name", "${workflow.input.name}"));
+
+var executor = new WorkflowExecutor(configuration);
+executor.RegisterWorkflow(workflow, overwrite: true);
+
+// Start the workflow
+var workflowClient = configuration.GetClient<WorkflowResourceApi>();
+var workflowId = workflowClient.StartWorkflow(
+    name: "greetings",
+    body: new Dictionary<string, object> { ["name"] = "World" },
+    version: 1
+);
+
+Console.WriteLine($"Started workflow: {workflowId}");
+// Open http://localhost:8080 to see the execution in the UI
+```
+
 ## Configurations
 
 ### Authentication Settings (Optional)
@@ -60,4 +134,4 @@ workflowClient.StartWorkflow(
 )
 ```
 
-### Next: [Create and run task workers](https://github.com/conductor-sdk/conductor-csharp/blob/main/docs/readme/workers.md)
+### Next: [Create and run task workers](https://github.com/conductor-oss/csharp-sdk/blob/main/docs/readme/workers.md)


### PR DESCRIPTION
## Summary

The C# SDK README had no working example — just a config snippet and a link. This adds a full Hello World covering the complete install → worker → workflow cycle against a local OSS Conductor server.

## What's added

**Step 1** — Start local server (Docker)

**Step 2** — Define a worker with `[WorkerTask]` attribute and run it:
```csharp
var configuration = new Configuration { BasePath = "http://localhost:8080/api" };
var host = WorkflowTaskHost.CreateWorkerHost(configuration, LogLevel.Information, new GreetWorker());
await host.StartAsync();
```

**Step 3** — Register a workflow with `WorkflowExecutor` and start it via `WorkflowResourceApi`

Also updates the "Next" link from `conductor-sdk/conductor-csharp` → `conductor-oss/csharp-sdk` (supersedes #140).

## Notes
- `BasePath` defaults to `https://play.orkes.io/api` in the SDK — the Hello World explicitly sets `http://localhost:8080/api` so OSS users connect to their local server without needing env vars or auth
- Worker/workflow patterns are taken from existing test code in `Tests/Worker/`

Closes conductor-oss/getting-started#26

🤖 Generated with [Claude Code](https://claude.com/claude-code)