### PR TITLE
Add Hello World quickstart and fix old org links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dotnet add package conductor-csharp
 
 ```csharp
 using Conductor.Client;
+using Conductor.Client.Extensions;
 using Conductor.Client.Worker;
 using Conductor.Definition;
 using Conductor.Definition.TaskType;
@@ -97,6 +98,7 @@ await host.WaitForShutdownAsync();
 **Step 3: Add the worker class — create `GreetWorker.cs`**
 
 ```csharp
+using Conductor.Client.Extensions;
 using Conductor.Client.Interfaces;
 using Conductor.Client.Models;
 using Conductor.Client.Worker;

--- a/README.md
+++ b/README.md
@@ -16,12 +16,123 @@ Show support for the Conductor OSS.  Please help spread the awareness by starrin
 
 [![GitHub stars](https://img.shields.io/github/stars/conductor-oss/conductor.svg?style=social&label=Star&maxAge=)](https://GitHub.com/conductor-oss/conductor/)
 
-   
-### Setup Conductor C# Package​
+## Start Conductor Server
+
+If you don't already have a Conductor server running, start one with Docker:
+
+```shell
+docker run --init -p 8080:8080 conductoross/conductor:latest
+```
+
+The UI will be available at `http://localhost:8080` and the API at `http://localhost:8080/api`.
+
+## Setup Conductor C# Package
 
 ```shell
 dotnet add package conductor-csharp
 ```
+
+## Hello World
+
+This quickstart shows the full flow: define a worker, define a workflow, register it, run it.
+
+**Step 1: Create a new console project**
+
+```shell
+dotnet new console -n conductor-hello
+cd conductor-hello
+dotnet add package conductor-csharp
+```
+
+**Step 2: Replace `Program.cs` with the following**
+
+```csharp
+using Conductor.Client;
+using Conductor.Client.Worker;
+using Conductor.Definition;
+using Conductor.Definition.TaskType;
+using Conductor.Executor;
+
+// Configure the SDK — reads CONDUCTOR_SERVER_URL from the environment,
+// or falls back to a local server.
+var configuration = new Configuration
+{
+    BasePath = Environment.GetEnvironmentVariable("CONDUCTOR_SERVER_URL")
+               ?? "http://localhost:8080/api"
+};
+
+// Define the workflow: one SIMPLE task called "greet".
+var workflow = new ConductorWorkflow()
+    .WithName("greetings")
+    .WithVersion(1);
+
+var greetTask = new SimpleTask("greet", "greet_ref")
+    .WithInput("name", workflow.Input("name"));
+workflow.WithTask(greetTask);
+
+// Register the workflow definition on the server.
+var executor = new WorkflowExecutor(configuration);
+executor.RegisterWorkflow(workflow, overwrite: true);
+
+// Start the worker host — it discovers GreetWorker automatically.
+var host = WorkflowTaskHost.CreateWorkerHost(
+    Microsoft.Extensions.Logging.LogLevel.Information,
+    new GreetWorker());
+await host.StartAsync();
+
+// Run the workflow and print the execution ID.
+var workflowId = executor.StartWorkflow(new StartWorkflowRequest
+{
+    Name = "greetings",
+    Version = 1,
+    Input = new Dictionary<string, object> { ["name"] = "Conductor" }
+});
+Console.WriteLine($"Started workflow: {workflowId}");
+Console.WriteLine($"View execution: http://localhost:8080/execution/{workflowId}");
+
+// Keep the worker running until Ctrl-C.
+await host.WaitForShutdownAsync();
+```
+
+**Step 3: Add the worker class — create `GreetWorker.cs`**
+
+```csharp
+using Conductor.Client.Interfaces;
+using Conductor.Client.Models;
+using Conductor.Client.Worker;
+using Task = Conductor.Client.Models.Task;
+
+public class GreetWorker : IWorkflowTask
+{
+    public string TaskType => "greet";
+    public WorkflowTaskExecutorConfiguration WorkerSettings { get; } = new();
+
+    public TaskResult Execute(Task task)
+    {
+        var name = task.InputData.GetValueOrDefault("name")?.ToString() ?? "World";
+        var result = task.Completed();
+        result.OutputData = new Dictionary<string, object>
+        {
+            ["greeting"] = $"Hello, {name}!"
+        };
+        return result;
+    }
+}
+```
+
+**Step 4: Run it**
+
+```shell
+dotnet run
+```
+
+Expected output:
+```
+Started workflow: <workflow-id>
+View execution: http://localhost:8080/execution/<workflow-id>
+```
+
+Open the UI link to see the completed execution and its output.
 
 ## Configurations
 
@@ -60,4 +171,4 @@ workflowClient.StartWorkflow(
 )
 ```
 
-### Next: [Create and run task workers](https://github.com/conductor-sdk/conductor-csharp/blob/main/docs/readme/workers.md)
+### Next: [Create and run task workers](https://github.com/conductor-oss/csharp-sdk/blob/main/docs/readme/workers.md)

--- a/docs/readme/workers.md
+++ b/docs/readme/workers.md
@@ -48,7 +48,7 @@ await host.startAsync();
 Thread.Sleep(TimeSpan.FromSeconds(100));
 ```
 
-Check out our [integration tests](https://github.com/conductor-sdk/conductor-csharp/blob/92c7580156a89322717c94aeaea9e5201fe577eb/Tests/Worker/WorkerTests.cs#L37) for more examples
+Check out our [integration tests](https://github.com/conductor-oss/csharp-sdk/blob/main/Tests/Worker/WorkerTests.cs) for more examples
 
 Worker SDK collects the following metrics:
 
@@ -65,4 +65,4 @@ Worker SDK collects the following metrics:
 
 Metrics on client side supplements the one collected from server in identifying the network as well as client side issues.
 
-### Next: [Create and Execute Workflows](https://github.com/conductor-sdk/conductor-csharp/blob/main/docs/readme/workflow.md)
+### Next: [Create and Execute Workflows](https://github.com/conductor-oss/csharp-sdk/blob/main/docs/readme/workflow.md)


### PR DESCRIPTION
## Summary

- Adds a **Start Conductor Server** section (Docker one-liner) so new users know how to get a server running
- Adds a **Hello World** section with a full install-to-running-worker flow (new console project → `GreetWorker` → workflow registration → run), matching the depth of the Python and Go SDK READMEs
- Fixes the **"Next"** link at the bottom of `README.md`: was pointing to the old `conductor-sdk/conductor-csharp` org, now points to `conductor-oss/csharp-sdk`
- Fixes two more stale `conductor-sdk` links in `docs/readme/workers.md` (integration tests link + "Next" link)

**User impact:** First-time users following the README had no working example to copy-paste, and the "Next" link at the bottom quietly redirected them to the old org. Now they get a complete install-to-running-worker quickstart and all links go to the right place.

Fixes conductor-oss/getting-started#26

## Test plan

- [ ] Verify `dotnet run` works against a local Conductor server using the Hello World code
- [ ] Confirm the "Next" link in README resolves to `conductor-oss/csharp-sdk`
- [ ] Confirm the workers.md integration test link and "Next" link resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)