### PR TITLE
Implement Metrics

### DIFF
--- a/Conductor/Client/ApiClient.cs
+++ b/Conductor/Client/ApiClient.cs
@@ -10,12 +10,14 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+using Conductor.Client.Telemetry;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RestSharp;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -29,6 +31,12 @@ namespace Conductor.Client
     /// </summary>
     public partial class ApiClient
     {
+        /// <summary>
+        /// Optional metrics collector for recording http_api_client_request_seconds.
+        /// Set once via DI or startup; safe to leave null.
+        /// </summary>
+        public static MetricsCollector Metrics { get; set; }
+
         public JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
@@ -179,11 +187,30 @@ namespace Conductor.Client
             Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams,
             String contentType, Configuration configuration)
         {
-            int retryCount = 0;
-            RestResponse response = RetryRestClientCallApi(path, method, queryParams, postBody, headerParams,
-                formParams, fileParams, pathParams, contentType, configuration, ref retryCount);
-
-            return (Object)response;
+            var sw = Stopwatch.StartNew();
+            string statusCode = "0";
+            try
+            {
+                int retryCount = 0;
+                RestResponse response = RetryRestClientCallApi(path, method, queryParams, postBody, headerParams,
+                    formParams, fileParams, pathParams, contentType, configuration, ref retryCount);
+                statusCode = ((int)response.StatusCode).ToString();
+                return (Object)response;
+            }
+            catch
+            {
+                statusCode = "0";
+                throw;
+            }
+            finally
+            {
+                sw.Stop();
+                var resolvedUri = path;
+                foreach (var param in pathParams)
+                    resolvedUri = resolvedUri.Replace("{" + param.Key + "}", param.Value);
+                var basePath = RestClient.Options.BaseUrl?.AbsolutePath?.TrimEnd('/') ?? "";
+                Metrics?.RecordHttpApiClientRequest(method.ToString().ToUpperInvariant(), basePath + resolvedUri, statusCode, sw.Elapsed.TotalSeconds);
+            }
         }
 
         private RestResponse RetryRestClientCallApi(String path, Method method, List<KeyValuePair<String, String>> queryParams, Object postBody,
@@ -226,15 +253,35 @@ namespace Conductor.Client
             Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams,
             String contentType)
         {
-            var request = PrepareRequest(
-                path, method, queryParams, postBody, headerParams, formParams, fileParams,
-                pathParams, contentType);
+            var sw = Stopwatch.StartNew();
+            string statusCode = "0";
+            try
+            {
+                var request = PrepareRequest(
+                    path, method, queryParams, postBody, headerParams, formParams, fileParams,
+                    pathParams, contentType);
 
-            InterceptRequest(request);
-            var response = await RestClient.ExecuteAsync(request, method);
-            InterceptResponse(request, response);
-            FormatHeaders(response);
-            return (object)response;
+                InterceptRequest(request);
+                var response = await RestClient.ExecuteAsync(request, method);
+                InterceptResponse(request, response);
+                FormatHeaders(response);
+                statusCode = ((int)response.StatusCode).ToString();
+                return (object)response;
+            }
+            catch
+            {
+                statusCode = "0";
+                throw;
+            }
+            finally
+            {
+                sw.Stop();
+                var resolvedUri = path;
+                foreach (var param in pathParams)
+                    resolvedUri = resolvedUri.Replace("{" + param.Key + "}", param.Value);
+                var basePath = RestClient.Options.BaseUrl?.AbsolutePath?.TrimEnd('/') ?? "";
+                Metrics?.RecordHttpApiClientRequest(method.ToString().ToUpperInvariant(), basePath + resolvedUri, statusCode, sw.Elapsed.TotalSeconds);
+            }
         }
 
         /// <summary>

--- a/Conductor/Client/Extensions/DependencyInjectionExtensions.cs
+++ b/Conductor/Client/Extensions/DependencyInjectionExtensions.cs
@@ -39,7 +39,12 @@ namespace Conductor.Client.Extensions
             }
             services.AddSingleton<Configuration>(configuration);
             services.AddSingleton<IWorkflowTaskClient, WorkflowTaskHttpClient>();
-            services.AddSingleton<MetricsCollector>();
+            services.AddSingleton<MetricsCollector>(sp =>
+            {
+                var collector = new MetricsCollector();
+                ApiClient.Metrics = collector;
+                return collector;
+            });
             services.AddTransient<IWorkflowTaskCoordinator, WorkflowTaskCoordinator>();
             return services;
         }

--- a/Conductor/Client/Telemetry/MetricsCollector.cs
+++ b/Conductor/Client/Telemetry/MetricsCollector.cs
@@ -39,6 +39,12 @@ namespace Conductor.Client.Telemetry
         public static readonly double[] CanonicalTimeBuckets =
             { 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 };
 
+        /// <summary>
+        /// Proposed size histogram buckets (in bytes); if accepted, will be shared across all Conductor SDKs.
+        /// </summary>
+        public static readonly double[] CanonicalSizeBuckets =
+            { 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000 };
+
         private readonly Meter _meter;
         private MeterProvider _meterProvider;
 
@@ -61,6 +67,8 @@ namespace Conductor.Client.Telemetry
         private readonly Histogram<double> _taskExecuteTimeSeconds;
         private readonly Histogram<double> _taskUpdateTimeSeconds;
         private readonly Histogram<double> _httpApiClientRequestSeconds;
+        private readonly Histogram<double> _taskResultSizeBytesHistogram;
+        private readonly Histogram<double> _workflowInputSizeBytesHistogram;
 
         // --- gauges ---
         private readonly ConcurrentDictionary<string, int> _activeWorkerCounts = new ConcurrentDictionary<string, int>();
@@ -143,6 +151,18 @@ namespace Conductor.Client.Telemetry
                 unit: "s",
                 description: "HTTP API client request duration in seconds");
 
+            // --- size histograms (non-canonical names while spec uses gauges) ---
+
+            _taskResultSizeBytesHistogram = _meter.CreateHistogram<double>(
+                "task_result_size_bytes_histogram",
+                unit: "By",
+                description: "Distribution of task result payload sizes in bytes");
+
+            _workflowInputSizeBytesHistogram = _meter.CreateHistogram<double>(
+                "workflow_input_size_bytes_histogram",
+                unit: "By",
+                description: "Distribution of workflow input payload sizes in bytes");
+
             // --- canonical size gauges ---
 
             _meter.CreateObservableGauge(
@@ -218,6 +238,8 @@ namespace Conductor.Client.Telemetry
                 .AddView("task_execute_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
                 .AddView("task_update_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
                 .AddView("http_api_client_request_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
+                .AddView("task_result_size_bytes_histogram", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalSizeBuckets })
+                .AddView("workflow_input_size_bytes_histogram", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalSizeBuckets })
                 .AddPrometheusHttpListener(options =>
                 {
                     options.UriPrefixes = new[] { $"http://*:{port}/" };
@@ -304,11 +326,16 @@ namespace Conductor.Client.Telemetry
         public void RecordTaskResultSize(string taskType, double sizeBytes)
         {
             _taskResultSizes[taskType] = sizeBytes;
+            _taskResultSizeBytesHistogram.Record(sizeBytes,
+                new KeyValuePair<string, object>("taskType", taskType));
         }
 
         public void RecordWorkflowInputSize(string workflowType, string version, double sizeBytes)
         {
             _workflowInputSizes[workflowType + "\0" + (version ?? "")] = sizeBytes;
+            _workflowInputSizeBytesHistogram.Record(sizeBytes,
+                new KeyValuePair<string, object>("workflowType", workflowType),
+                new KeyValuePair<string, object>("version", version ?? ""));
         }
 
         // ---------------------------------------------------------------

--- a/Conductor/Client/Telemetry/MetricsCollector.cs
+++ b/Conductor/Client/Telemetry/MetricsCollector.cs
@@ -405,7 +405,7 @@ namespace Conductor.Client.Telemetry
             _externalPayloadUsedTotal.Add(1,
                 new KeyValuePair<string, object>("entityName", entityName),
                 new KeyValuePair<string, object>("operation", operation),
-                new KeyValuePair<string, object>("payloadType", payloadType));
+                new KeyValuePair<string, object>("payload_type", payloadType));
         }
 
         // ---------------------------------------------------------------

--- a/Conductor/Client/Telemetry/MetricsCollector.cs
+++ b/Conductor/Client/Telemetry/MetricsCollector.cs
@@ -10,9 +10,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
 
 namespace Conductor.Client.Telemetry
 {
@@ -20,18 +23,28 @@ namespace Conductor.Client.Telemetry
     /// Instruments the Conductor worker poll-execute-update loop with
     /// <see cref="System.Diagnostics.Metrics"/> counters, histograms, and gauges.
     ///
-    /// The <see cref="Meter"/> is named <c>Conductor.Client</c>. To expose these
-    /// metrics, attach a listener such as the OpenTelemetry Prometheus exporter
-    /// (see METRICS.md for examples).
+    /// The <see cref="Meter"/> is named <c>Conductor.Client</c>. Call
+    /// <see cref="StartServer(int)"/> to expose a Prometheus-compatible
+    /// <c>/metrics</c> endpoint with the canonical bucket configuration,
+    /// or attach your own <see cref="MeterProvider"/> using
+    /// <see cref="CanonicalTimeBuckets"/>.
     /// </summary>
-    public sealed class MetricsCollector
+    public sealed class MetricsCollector : IDisposable
     {
         public const string MeterName = "Conductor.Client";
 
+        /// <summary>
+        /// Canonical time histogram buckets shared across all Conductor SDKs.
+        /// </summary>
+        public static readonly double[] CanonicalTimeBuckets =
+            { 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 };
+
         private readonly Meter _meter;
+        private MeterProvider _meterProvider;
 
         // --- counters ---
         private readonly Counter<long> _taskPollTotal;
+        private readonly Counter<long> _taskExecutionStartedTotal;
         private readonly Counter<long> _taskPollErrorTotal;
         private readonly Counter<long> _taskExecuteErrorTotal;
         private readonly Counter<long> _taskUpdateErrorTotal;
@@ -40,24 +53,33 @@ namespace Conductor.Client.Telemetry
         private readonly Counter<long> _threadUncaughtExceptionsTotal;
         private readonly Counter<long> _workflowStartErrorTotal;
         private readonly Counter<long> _externalPayloadUsedTotal;
+        private readonly Counter<long> _taskAckErrorTotal;
+        private readonly Counter<long> _taskAckFailedTotal;
 
         // --- histograms ---
         private readonly Histogram<double> _taskPollTimeSeconds;
         private readonly Histogram<double> _taskExecuteTimeSeconds;
         private readonly Histogram<double> _taskUpdateTimeSeconds;
-        private readonly Histogram<double> _taskResultSizeBytes;
-        private readonly Histogram<double> _workflowInputSizeBytes;
+        private readonly Histogram<double> _httpApiClientRequestSeconds;
 
         // --- gauges ---
         private readonly ConcurrentDictionary<string, int> _activeWorkerCounts = new ConcurrentDictionary<string, int>();
+        private readonly ConcurrentDictionary<string, double> _taskResultSizes = new ConcurrentDictionary<string, double>();
+        private readonly ConcurrentDictionary<string, double> _workflowInputSizes = new ConcurrentDictionary<string, double>();
 
         public MetricsCollector()
         {
             _meter = new Meter(MeterName);
 
+            // --- counters ---
+
             _taskPollTotal = _meter.CreateCounter<long>(
                 "task_poll_total",
                 description: "Total number of task poll attempts");
+
+            _taskExecutionStartedTotal = _meter.CreateCounter<long>(
+                "task_execution_started_total",
+                description: "Tasks dispatched to the worker function");
 
             _taskPollErrorTotal = _meter.CreateCounter<long>(
                 "task_poll_error_total",
@@ -91,6 +113,16 @@ namespace Conductor.Client.Telemetry
                 "external_payload_used_total",
                 description: "External payload storage usage");
 
+            _taskAckErrorTotal = _meter.CreateCounter<long>(
+                "task_ack_error_total",
+                description: "Task ack client-side errors");
+
+            _taskAckFailedTotal = _meter.CreateCounter<long>(
+                "task_ack_failed_total",
+                description: "Task ack declined by server");
+
+            // --- time histograms ---
+
             _taskPollTimeSeconds = _meter.CreateHistogram<double>(
                 "task_poll_time_seconds",
                 unit: "s",
@@ -106,15 +138,50 @@ namespace Conductor.Client.Telemetry
                 unit: "s",
                 description: "Task result update duration in seconds");
 
-            _taskResultSizeBytes = _meter.CreateHistogram<double>(
+            _httpApiClientRequestSeconds = _meter.CreateHistogram<double>(
+                "http_api_client_request_seconds",
+                unit: "s",
+                description: "HTTP API client request duration in seconds");
+
+            // --- canonical size gauges ---
+
+            _meter.CreateObservableGauge(
                 "task_result_size_bytes",
+                observeValues: () =>
+                {
+                    var measurements = new List<Measurement<double>>();
+                    foreach (var kvp in _taskResultSizes)
+                    {
+                        measurements.Add(new Measurement<double>(
+                            kvp.Value,
+                            new KeyValuePair<string, object>("taskType", kvp.Key)));
+                    }
+                    return measurements;
+                },
                 unit: "By",
                 description: "Size of task result payload in bytes");
 
-            _workflowInputSizeBytes = _meter.CreateHistogram<double>(
+            _meter.CreateObservableGauge(
                 "workflow_input_size_bytes",
+                observeValues: () =>
+                {
+                    var measurements = new List<Measurement<double>>();
+                    foreach (var kvp in _workflowInputSizes)
+                    {
+                        var parts = kvp.Key.Split('\0');
+                        var wfType = parts[0];
+                        var version = parts.Length > 1 ? parts[1] : "";
+                        measurements.Add(new Measurement<double>(
+                            kvp.Value,
+                            new KeyValuePair<string, object>("workflowType", wfType),
+                            new KeyValuePair<string, object>("version", version)));
+                    }
+                    return measurements;
+                },
                 unit: "By",
                 description: "Size of workflow input payload in bytes");
+
+            // --- utilization gauge ---
 
             _meter.CreateObservableGauge(
                 "active_workers",
@@ -125,11 +192,43 @@ namespace Conductor.Client.Telemetry
                     {
                         measurements.Add(new Measurement<int>(
                             kvp.Value,
-                            new KeyValuePair<string, object>("task_type", kvp.Key)));
+                            new KeyValuePair<string, object>("taskType", kvp.Key)));
                     }
                     return measurements;
                 },
                 description: "Number of workers currently executing tasks");
+        }
+
+        // ---------------------------------------------------------------
+        // Built-in Prometheus server
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Starts an OpenTelemetry Prometheus HTTP listener on the given port
+        /// with the canonical bucket configuration for all histograms.
+        /// </summary>
+        public void StartServer(int port)
+        {
+            if (_meterProvider != null)
+                throw new InvalidOperationException("Metrics server already started");
+
+            _meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(MeterName)
+                .AddView("task_poll_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
+                .AddView("task_execute_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
+                .AddView("task_update_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
+                .AddView("http_api_client_request_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = CanonicalTimeBuckets })
+                .AddPrometheusHttpListener(options =>
+                {
+                    options.UriPrefixes = new[] { $"http://*:{port}/" };
+                })
+                .Build();
+        }
+
+        public void Dispose()
+        {
+            _meterProvider?.Dispose();
+            _meter?.Dispose();
         }
 
         // ---------------------------------------------------------------
@@ -138,53 +237,64 @@ namespace Conductor.Client.Telemetry
 
         public void RecordTaskPoll(string taskType)
         {
-            _taskPollTotal.Add(1, new KeyValuePair<string, object>("task_type", taskType));
+            _taskPollTotal.Add(1,
+                new KeyValuePair<string, object>("taskType", taskType));
         }
 
-        public void RecordTaskPollTime(string taskType, double durationSeconds)
+        public void RecordTaskPollTime(string taskType, double durationSeconds, string status)
         {
             _taskPollTimeSeconds.Record(durationSeconds,
-                new KeyValuePair<string, object>("task_type", taskType));
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("status", status));
         }
 
-        public void RecordTaskPollError(string taskType, string errorType)
+        public void RecordTaskPollError(string taskType, string exceptionType)
         {
             _taskPollErrorTotal.Add(1,
-                new KeyValuePair<string, object>("task_type", taskType),
-                new KeyValuePair<string, object>("error_type", errorType));
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("exception", exceptionType));
         }
 
         // ---------------------------------------------------------------
         // Execution
         // ---------------------------------------------------------------
 
-        public void RecordTaskExecuteTime(string taskType, double durationSeconds)
+        public void RecordTaskExecutionStarted(string taskType)
         {
-            _taskExecuteTimeSeconds.Record(durationSeconds,
-                new KeyValuePair<string, object>("task_type", taskType));
+            _taskExecutionStartedTotal.Add(1,
+                new KeyValuePair<string, object>("taskType", taskType));
         }
 
-        public void RecordTaskExecuteError(string taskType, string errorType)
+        public void RecordTaskExecuteTime(string taskType, double durationSeconds, string status)
+        {
+            _taskExecuteTimeSeconds.Record(durationSeconds,
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("status", status));
+        }
+
+        public void RecordTaskExecuteError(string taskType, string exceptionType)
         {
             _taskExecuteErrorTotal.Add(1,
-                new KeyValuePair<string, object>("task_type", taskType),
-                new KeyValuePair<string, object>("error_type", errorType));
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("exception", exceptionType));
         }
 
         // ---------------------------------------------------------------
         // Update
         // ---------------------------------------------------------------
 
-        public void RecordTaskUpdateTime(string taskType, double durationSeconds)
+        public void RecordTaskUpdateTime(string taskType, double durationSeconds, string status)
         {
             _taskUpdateTimeSeconds.Record(durationSeconds,
-                new KeyValuePair<string, object>("task_type", taskType));
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("status", status));
         }
 
-        public void RecordTaskUpdateError(string taskType)
+        public void RecordTaskUpdateError(string taskType, string exceptionType)
         {
             _taskUpdateErrorTotal.Add(1,
-                new KeyValuePair<string, object>("task_type", taskType));
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("exception", exceptionType));
         }
 
         // ---------------------------------------------------------------
@@ -193,15 +303,24 @@ namespace Conductor.Client.Telemetry
 
         public void RecordTaskResultSize(string taskType, double sizeBytes)
         {
-            _taskResultSizeBytes.Record(sizeBytes,
-                new KeyValuePair<string, object>("task_type", taskType));
+            _taskResultSizes[taskType] = sizeBytes;
         }
 
         public void RecordWorkflowInputSize(string workflowType, string version, double sizeBytes)
         {
-            _workflowInputSizeBytes.Record(sizeBytes,
-                new KeyValuePair<string, object>("workflow_type", workflowType),
-                new KeyValuePair<string, object>("version", version));
+            _workflowInputSizes[workflowType + "\0" + (version ?? "")] = sizeBytes;
+        }
+
+        // ---------------------------------------------------------------
+        // HTTP API client
+        // ---------------------------------------------------------------
+
+        public void RecordHttpApiClientRequest(string method, string uri, string status, double durationSeconds)
+        {
+            _httpApiClientRequestSeconds.Record(durationSeconds,
+                new KeyValuePair<string, object>("method", method),
+                new KeyValuePair<string, object>("uri", uri),
+                new KeyValuePair<string, object>("status", status));
         }
 
         // ---------------------------------------------------------------
@@ -211,13 +330,13 @@ namespace Conductor.Client.Telemetry
         public void RecordTaskExecutionQueueFull(string taskType)
         {
             _taskExecutionQueueFullTotal.Add(1,
-                new KeyValuePair<string, object>("task_type", taskType));
+                new KeyValuePair<string, object>("taskType", taskType));
         }
 
         public void RecordTaskPaused(string taskType)
         {
             _taskPausedTotal.Add(1,
-                new KeyValuePair<string, object>("task_type", taskType));
+                new KeyValuePair<string, object>("taskType", taskType));
         }
 
         // ---------------------------------------------------------------
@@ -230,26 +349,53 @@ namespace Conductor.Client.Telemetry
         }
 
         // ---------------------------------------------------------------
-        // Uncategorised
+        // Uncaught exceptions
         // ---------------------------------------------------------------
 
-        public void RecordUncaughtException()
+        public void RecordUncaughtException(string exceptionType)
         {
-            _threadUncaughtExceptionsTotal.Add(1);
+            _threadUncaughtExceptionsTotal.Add(1,
+                new KeyValuePair<string, object>("exception", exceptionType));
         }
 
-        public void RecordWorkflowStartError(string workflowType)
+        // ---------------------------------------------------------------
+        // Workflow
+        // ---------------------------------------------------------------
+
+        public void RecordWorkflowStartError(string workflowType, string exceptionType)
         {
             _workflowStartErrorTotal.Add(1,
-                new KeyValuePair<string, object>("workflow_type", workflowType));
+                new KeyValuePair<string, object>("workflowType", workflowType),
+                new KeyValuePair<string, object>("exception", exceptionType));
         }
+
+        // ---------------------------------------------------------------
+        // External payload
+        // ---------------------------------------------------------------
 
         public void RecordExternalPayloadUsed(string entityName, string operation, string payloadType)
         {
             _externalPayloadUsedTotal.Add(1,
-                new KeyValuePair<string, object>("entity_name", entityName),
+                new KeyValuePair<string, object>("entityName", entityName),
                 new KeyValuePair<string, object>("operation", operation),
-                new KeyValuePair<string, object>("payload_type", payloadType));
+                new KeyValuePair<string, object>("payloadType", payloadType));
+        }
+
+        // ---------------------------------------------------------------
+        // Surface-only ack counters (internal runner never increments)
+        // ---------------------------------------------------------------
+
+        public void RecordTaskAckError(string taskType, string exceptionType)
+        {
+            _taskAckErrorTotal.Add(1,
+                new KeyValuePair<string, object>("taskType", taskType),
+                new KeyValuePair<string, object>("exception", exceptionType));
+        }
+
+        public void RecordTaskAckFailed(string taskType)
+        {
+            _taskAckFailedTotal.Add(1,
+                new KeyValuePair<string, object>("taskType", taskType));
         }
     }
 }

--- a/Conductor/Client/Telemetry/MetricsCollector.cs
+++ b/Conductor/Client/Telemetry/MetricsCollector.cs
@@ -405,7 +405,7 @@ namespace Conductor.Client.Telemetry
             _externalPayloadUsedTotal.Add(1,
                 new KeyValuePair<string, object>("entityName", entityName),
                 new KeyValuePair<string, object>("operation", operation),
-                new KeyValuePair<string, object>("payload_type", payloadType));
+                new KeyValuePair<string, object>("payloadType", payloadType));
         }
 
         // ---------------------------------------------------------------

--- a/Conductor/Client/Worker/WorkflowTaskExecutor.cs
+++ b/Conductor/Client/Worker/WorkflowTaskExecutor.cs
@@ -108,7 +108,7 @@ namespace Conductor.Client.Worker
                 }
                 catch (Exception e)
                 {
-                    _metrics?.RecordUncaughtException();
+                    _metrics?.RecordUncaughtException(e.GetType().Name);
                     _logger.LogError(
                         $"[{_workerSettings.WorkerId}] worker error: {e.Message}"
                         + $", taskName: {_worker.TaskType}"
@@ -171,7 +171,7 @@ namespace Conductor.Client.Worker
                 var tasks = _taskClient.PollTask(_worker.TaskType, _workerSettings.WorkerId, _workerSettings.Domain,
                     availableWorkerCounter);
                 pollStopwatch.Stop();
-                _metrics?.RecordTaskPollTime(_worker.TaskType, pollStopwatch.Elapsed.TotalSeconds);
+                _metrics?.RecordTaskPollTime(_worker.TaskType, pollStopwatch.Elapsed.TotalSeconds, "SUCCESS");
 
                 if (tasks == null)
                 {
@@ -189,7 +189,7 @@ namespace Conductor.Client.Worker
             catch (Exception e)
             {
                 pollStopwatch.Stop();
-                _metrics?.RecordTaskPollTime(_worker.TaskType, pollStopwatch.Elapsed.TotalSeconds);
+                _metrics?.RecordTaskPollTime(_worker.TaskType, pollStopwatch.Elapsed.TotalSeconds, "FAILURE");
                 _metrics?.RecordTaskPollError(_worker.TaskType, e.GetType().Name);
                 _logger.LogTrace(
                     $"[{_workerSettings.WorkerId}] Polling error: {e.Message} "
@@ -235,6 +235,7 @@ namespace Conductor.Client.Worker
                 + $", CancelToken: {token}"
             );
 
+            _metrics?.RecordTaskExecutionStarted(_worker.TaskType);
             var executeStopwatch = Stopwatch.StartNew();
             try
             {
@@ -244,7 +245,7 @@ namespace Conductor.Client.Worker
                 taskResult = await _worker.Execute(task, token);
 
                 executeStopwatch.Stop();
-                _metrics?.RecordTaskExecuteTime(_worker.TaskType, executeStopwatch.Elapsed.TotalSeconds);
+                _metrics?.RecordTaskExecuteTime(_worker.TaskType, executeStopwatch.Elapsed.TotalSeconds, "SUCCESS");
 
                 _logger.LogTrace(
                     $"[{_workerSettings.WorkerId}] Done processing task for worker"
@@ -259,7 +260,7 @@ namespace Conductor.Client.Worker
             catch (Exception e)
             {
                 executeStopwatch.Stop();
-                _metrics?.RecordTaskExecuteTime(_worker.TaskType, executeStopwatch.Elapsed.TotalSeconds);
+                _metrics?.RecordTaskExecuteTime(_worker.TaskType, executeStopwatch.Elapsed.TotalSeconds, "FAILURE");
                 _metrics?.RecordTaskExecuteError(_worker.TaskType, e.GetType().Name);
                 _logger.LogError(
                     $"[{_workerSettings.WorkerId}] Failed to process task for worker, reason: {e.Message}"
@@ -297,7 +298,7 @@ namespace Conductor.Client.Worker
 
                     _taskClient.UpdateTask(taskResult);
                     updateStopwatch.Stop();
-                    _metrics?.RecordTaskUpdateTime(_worker.TaskType, updateStopwatch.Elapsed.TotalSeconds);
+                    _metrics?.RecordTaskUpdateTime(_worker.TaskType, updateStopwatch.Elapsed.TotalSeconds, "SUCCESS");
                     _logger.LogTrace(
                         $"[{_workerSettings.WorkerId}] Done updating task"
                         + $", taskType: {_worker.TaskType}"
@@ -320,7 +321,8 @@ namespace Conductor.Client.Worker
             }
 
             updateStopwatch.Stop();
-            _metrics?.RecordTaskUpdateError(_worker.TaskType);
+            _metrics?.RecordTaskUpdateTime(_worker.TaskType, updateStopwatch.Elapsed.TotalSeconds, "FAILURE");
+            _metrics?.RecordTaskUpdateError(_worker.TaskType, "RetryExhaustedException");
             throw new Exception("Failed to update task after retries");
         }
 

--- a/Conductor/Executor/WorkflowExecutor.cs
+++ b/Conductor/Executor/WorkflowExecutor.cs
@@ -13,26 +13,32 @@
 using Conductor.Api;
 using Conductor.Client;
 using Conductor.Client.Models;
+using Conductor.Client.Telemetry;
 using Conductor.Definition;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Conductor.Executor
 {
     public class WorkflowExecutor
     {
-        private WorkflowResourceApi _workflowClient;
-        private MetadataResourceApi _metadataClient;
+        private readonly WorkflowResourceApi _workflowClient;
+        private readonly MetadataResourceApi _metadataClient;
+        private readonly MetricsCollector _metrics;
 
-        public WorkflowExecutor(Configuration configuration)
+        public WorkflowExecutor(Configuration configuration, MetricsCollector metrics = null)
         {
             _workflowClient = configuration.GetClient<WorkflowResourceApi>();
             _metadataClient = configuration.GetClient<MetadataResourceApi>();
+            _metrics = metrics;
         }
 
-        public WorkflowExecutor(WorkflowResourceApi workflowClient, MetadataResourceApi metadataClient)
+        public WorkflowExecutor(WorkflowResourceApi workflowClient, MetadataResourceApi metadataClient, MetricsCollector metrics = null)
         {
             _workflowClient = workflowClient;
             _metadataClient = metadataClient;
+            _metrics = metrics;
         }
 
         public void RegisterWorkflow(WorkflowDef workflow, bool overwrite)
@@ -54,7 +60,41 @@ namespace Conductor.Executor
 
         public string StartWorkflow(StartWorkflowRequest startWorkflowRequest)
         {
-            return _workflowClient.StartWorkflow(startWorkflowRequest);
+            RecordInputSize(startWorkflowRequest);
+            try
+            {
+                return _workflowClient.StartWorkflow(startWorkflowRequest);
+            }
+            catch (Exception ex)
+            {
+                _metrics?.RecordWorkflowStartError(
+                    startWorkflowRequest.Name ?? "",
+                    ex.GetType().Name);
+                throw;
+            }
+        }
+
+        private void RecordInputSize(StartWorkflowRequest request)
+        {
+            if (_metrics == null)
+                return;
+            try
+            {
+                double size = 0;
+                if (request.Input != null)
+                {
+                    var json = JsonConvert.SerializeObject(request.Input);
+                    size = json.Length;
+                }
+                _metrics.RecordWorkflowInputSize(
+                    request.Name ?? "",
+                    request.Version?.ToString() ?? "",
+                    size);
+            }
+            catch
+            {
+                // Don't let metrics serialization failures disrupt workflow start.
+            }
         }
     }
 }

--- a/Conductor/conductor-csharp.csproj
+++ b/Conductor/conductor-csharp.csproj
@@ -11,14 +11,16 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.1-beta.1" />
     <None Include="/package/Conductor/README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/Harness/Harness.csproj
+++ b/Harness/Harness.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.1-beta.1" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="../Conductor/conductor-csharp.csproj" />
   </ItemGroup>
 </Project>

--- a/Harness/Program.cs
+++ b/Harness/Program.cs
@@ -1,4 +1,3 @@
-using Conductor.Api;
 using Conductor.Client;
 using Conductor.Client.Extensions;
 using Conductor.Client.Telemetry;
@@ -6,8 +5,6 @@ using Conductor.Definition;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry;
-using OpenTelemetry.Metrics;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -43,24 +40,6 @@ namespace Harness
             var metricsPort = int.TryParse(
                 Environment.GetEnvironmentVariable("HARNESS_METRICS_PORT"), out var mp) ? mp : DefaultMetricsPort;
 
-            var timeBuckets = new double[] { 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 };
-            var sizeBuckets = new double[] { 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000 };
-
-            var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(MetricsCollector.MeterName)
-                .AddView("task_poll_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = timeBuckets })
-                .AddView("task_execute_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = timeBuckets })
-                .AddView("task_update_time_seconds", new ExplicitBucketHistogramConfiguration { Boundaries = timeBuckets })
-                .AddView("task_result_size_bytes", new ExplicitBucketHistogramConfiguration { Boundaries = sizeBuckets })
-                .AddView("workflow_input_size_bytes", new ExplicitBucketHistogramConfiguration { Boundaries = sizeBuckets })
-                .AddPrometheusHttpListener(options =>
-                {
-                    options.UriPrefixes = new[] { $"http://*:{metricsPort}/" };
-                })
-                .Build();
-
-            Console.WriteLine($"Prometheus metrics server started on port {metricsPort}");
-
             var host = new HostBuilder()
                 .ConfigureServices(services =>
                 {
@@ -71,12 +50,18 @@ namespace Harness
                     services.WithHostedService();
 
                     services.AddSingleton(config);
-                    services.AddHostedService(sp => new WorkflowGovernor(
-                        config,
-                        sp.GetRequiredService<ILogger<WorkflowGovernor>>(),
-                        WorkflowName,
-                        workflowsPerSec,
-                        sp.GetRequiredService<MetricsCollector>()));
+                    services.AddHostedService(sp =>
+                    {
+                        var metrics = sp.GetRequiredService<MetricsCollector>();
+                        metrics.StartServer(metricsPort);
+                        Console.WriteLine($"Prometheus metrics server started on port {metricsPort}");
+                        return new WorkflowGovernor(
+                            config,
+                            sp.GetRequiredService<ILogger<WorkflowGovernor>>(),
+                            WorkflowName,
+                            workflowsPerSec,
+                            metrics);
+                    });
                 })
                 .ConfigureLogging(logging =>
                 {
@@ -85,19 +70,12 @@ namespace Harness
                 })
                 .Build();
 
-            try
-            {
-                await host.RunAsync();
-            }
-            finally
-            {
-                meterProvider?.Dispose();
-            }
+            await host.RunAsync();
         }
 
         private static void RegisterMetadata(Configuration config)
         {
-            var metadataClient = config.GetClient<MetadataResourceApi>();
+            var metadataClient = config.GetClient<Conductor.Api.MetadataResourceApi>();
 
             var taskDefs = new List<Conductor.Client.Models.TaskDef>();
             foreach (var (taskName, codename, sleepSeconds) in SimulatedWorkers)

--- a/Harness/README.md
+++ b/Harness/README.md
@@ -58,7 +58,7 @@ All resource names use a `csharp_` prefix so multiple SDK harnesses (Python, Jav
 ### Metrics
 
 The harness exposes Prometheus metrics at `http://localhost:9991/metrics` via the OpenTelemetry
-Prometheus exporter. See [METRICS.md](../METRICS.md) for the full list of metrics, labels, and
+Prometheus exporter. See [metrics.md](../docs/metrics.md) for the full list of metrics, labels, and
 configuration options.
 
 ### Environment Variables

--- a/Harness/WorkflowGovernor.cs
+++ b/Harness/WorkflowGovernor.cs
@@ -1,6 +1,6 @@
-using Conductor.Api;
 using Conductor.Client;
 using Conductor.Client.Telemetry;
+using Conductor.Executor;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -11,11 +11,10 @@ namespace Harness
 {
     public class WorkflowGovernor : BackgroundService
     {
-        private readonly WorkflowResourceApi _workflowClient;
+        private readonly WorkflowExecutor _executor;
         private readonly ILogger<WorkflowGovernor> _logger;
         private readonly string _workflowName;
         private readonly int _workflowsPerSecond;
-        private readonly MetricsCollector _metrics;
 
         public WorkflowGovernor(
             Configuration config,
@@ -24,11 +23,10 @@ namespace Harness
             int workflowsPerSecond,
             MetricsCollector metrics = null)
         {
-            _workflowClient = config.GetClient<WorkflowResourceApi>();
+            _executor = new WorkflowExecutor(config, metrics);
             _logger = logger;
             _workflowName = workflowName;
             _workflowsPerSecond = workflowsPerSecond;
-            _metrics = metrics;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -43,15 +41,14 @@ namespace Harness
                 {
                     for (var i = 0; i < _workflowsPerSecond; i++)
                     {
-                        _workflowClient.StartWorkflow(
-                            new Conductor.Client.Models.StartWorkflowRequest(name: _workflowName));
+                        _executor.StartWorkflow(
+                            new Conductor.Client.Models.StartWorkflowRequest(name: _workflowName, version: 1));
                     }
 
                     _logger.LogInformation("Governor: started {Count} workflow(s)", _workflowsPerSecond);
                 }
                 catch (Exception ex)
                 {
-                    _metrics?.RecordWorkflowStartError(_workflowName);
                     _logger.LogError(ex, "Governor: error starting workflows");
                 }
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -9,38 +9,48 @@ compatible with any .NET metrics listener -- most notably the
 - [Quick Reference](#quick-reference)
 - [Configuration](#configuration)
   - [DI-Based Workers](#di-based-workers)
-  - [WorkflowTaskHost Convenience API](#workflowtaskhost-convenience-api)
-  - [Prometheus via OpenTelemetry](#prometheus-via-opentelemetry)
+  - [Built-in Prometheus Server (Recommended)](#built-in-prometheus-server-recommended)
+  - [Custom MeterProvider](#custom-meterprovider)
   - [Console Exporter (Development)](#console-exporter-development)
 - [Metric Types](#metric-types)
   - [Counters](#counters)
   - [Histograms](#histograms)
   - [Gauges](#gauges)
 - [Labels](#labels)
+  - [Dual-Emit Strategy (Phase 1)](#dual-emit-strategy-phase-1)
+  - [Deprecated Labels](#deprecated-labels)
+- [Histogram Bucket Boundaries](#histogram-bucket-boundaries)
 - [Example Metrics Output](#example-metrics-output)
+- [OTel Scope Label](#otel-scope-label)
 - [Best Practices](#best-practices)
 
 ## Quick Reference
 
 All metrics are registered under the meter named `Conductor.Client`.
 
-| Name | Type | Labels | Description |
-|---|---|---|---|
-| `task_poll_total` | Counter | `task_type` | Total task poll attempts |
-| `task_poll_error_total` | Counter | `task_type`, `error_type` | Total task poll errors |
-| `task_execute_error_total` | Counter | `task_type`, `error_type` | Total task execution errors |
-| `task_update_error_total` | Counter | `task_type` | Total task update errors (after all retries) |
-| `task_paused_total` | Counter | `task_type` | Polls skipped because the worker is paused |
-| `task_execution_queue_full_total` | Counter | `task_type` | Polls returning zero capacity (all workers busy) |
-| `thread_uncaught_exceptions_total` | Counter | -- | Uncaught exceptions in worker threads |
-| `workflow_start_error_total` | Counter | `workflow_type` | Errors starting workflows |
-| `external_payload_used_total` | Counter | `entity_name`, `operation`, `payload_type` | External payload storage usage |
-| `task_poll_time_seconds` | Histogram | `task_type` | Task poll round-trip duration (seconds) |
-| `task_execute_time_seconds` | Histogram | `task_type` | Task execution duration (seconds) |
-| `task_update_time_seconds` | Histogram | `task_type` | Task result update duration (seconds) |
-| `task_result_size_bytes` | Histogram | `task_type` | Task result payload size (bytes) |
-| `workflow_input_size_bytes` | Histogram | `workflow_type`, `version` | Workflow input payload size (bytes) |
-| `active_workers` | Gauge | `task_type` | Workers currently executing tasks |
+| Name | Type | Canonical Labels | Deprecated Labels | Description |
+|---|---|---|---|---|
+| `task_poll_total` | Counter | `taskType` | `task_type` | Total task poll attempts |
+| `task_execution_started_total` | Counter | `taskType` | `task_type` | Tasks dispatched to the worker function |
+| `task_poll_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task poll errors |
+| `task_execute_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task execution errors |
+| `task_update_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task update errors (after all retries) |
+| `task_ack_error_total` | Counter | `taskType`, `exception` | `task_type` | Task ack client-side errors (surface-only) |
+| `task_ack_failed_total` | Counter | `taskType` | `task_type` | Task ack declined by server (surface-only) |
+| `task_paused_total` | Counter | `taskType` | `task_type` | Polls skipped because the worker is paused |
+| `task_execution_queue_full_total` | Counter | `taskType` | `task_type` | Polls returning zero capacity (all workers busy) |
+| `thread_uncaught_exceptions_total` | Counter | `exception` | -- | Uncaught exceptions in worker threads |
+| `workflow_start_error_total` | Counter | `workflowType`, `exception` | `workflow_type` | Errors starting workflows |
+| `external_payload_used_total` | Counter | `entityName`, `operation`, `payload_type` | `entity_name` | External payload storage usage |
+| `task_poll_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task poll round-trip duration (seconds) |
+| `task_execute_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task execution duration (seconds) |
+| `task_update_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task result update duration (seconds) |
+| `http_api_client_request_seconds` | Histogram | `method`, `uri`, `status` | -- | HTTP API client request duration (seconds) |
+| `task_result_size_bytes` | **Gauge** | `taskType` | `task_type` | Task result payload size (bytes) — last value |
+| `task_result_size_bytes_histogram` | Histogram | `taskType` | `task_type` | **[DEPRECATED]** Task result payload size (bytes) |
+| `workflow_input_size_bytes` | **Gauge** | `workflowType`, `version` | `workflow_type` | Workflow input payload size (bytes) — last value |
+| `workflow_input_size_bytes_histogram` | Histogram | `workflowType`, `version` | `workflow_type` | **[DEPRECATED]** Workflow input payload size (bytes) |
+| `active_workers` | Gauge | `taskType` | `task_type` | Workers currently executing tasks |
 
 ## Configuration
 
@@ -62,29 +72,29 @@ var host = new HostBuilder()
     .Build();
 ```
 
-To **expose** the metrics externally (e.g. Prometheus scraping), attach a metrics listener
-or exporter as shown below.
+To **expose** the metrics externally (e.g. Prometheus scraping), use the built-in server
+or attach your own exporter as shown below.
 
-### WorkflowTaskHost Convenience API
+### Built-in Prometheus Server (Recommended)
 
-If you use the one-liner `WorkflowTaskHost.CreateWorkerHost(...)`, metrics are registered
-automatically via the same `AddConductorWorker()` call:
+The simplest way to expose a `/metrics` endpoint is to call `MetricsCollector.StartServer(port)`.
+This configures the OpenTelemetry `MeterProvider` with canonical histogram bucket boundaries
+and starts a Prometheus HTTP listener on the given port:
 
 ```csharp
-var host = WorkflowTaskHost.CreateWorkerHost(config, workers: new MyWorker());
-await host.RunAsync();
+var metrics = serviceProvider.GetRequiredService<MetricsCollector>();
+metrics.StartServer(9991);
+// Prometheus scrape endpoint now at http://localhost:9991/metrics
 ```
 
-### Prometheus via OpenTelemetry
+This is equivalent to what every other Conductor SDK provides (Python, Go, Java, Ruby, Rust)
+and is the recommended setup for production use.
 
-Add the following NuGet packages to your project:
+### Custom MeterProvider
 
-```
-dotnet add package OpenTelemetry
-dotnet add package OpenTelemetry.Exporter.Prometheus.HttpListener --prerelease
-```
-
-Then configure a `MeterProvider` before starting the host:
+If you need full control (e.g. adding additional exporters, custom Views, or extra meters),
+you can configure your own `MeterProvider`. Use the SDK's canonical bucket constants
+to stay aligned with the fleet:
 
 ```csharp
 using OpenTelemetry;
@@ -92,20 +102,25 @@ using OpenTelemetry.Metrics;
 using Conductor.Client.Telemetry;
 
 var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .AddMeter(MetricsCollector.MeterName)   // "Conductor.Client"
+    .AddMeter(MetricsCollector.MeterName)
+    .AddView("task_poll_time_seconds",
+        new ExplicitBucketHistogramConfiguration
+        { Boundaries = MetricsCollector.CanonicalTimeBuckets })
+    .AddView("task_execute_time_seconds",
+        new ExplicitBucketHistogramConfiguration
+        { Boundaries = MetricsCollector.CanonicalTimeBuckets })
+    .AddView("task_update_time_seconds",
+        new ExplicitBucketHistogramConfiguration
+        { Boundaries = MetricsCollector.CanonicalTimeBuckets })
+    .AddView("http_api_client_request_seconds",
+        new ExplicitBucketHistogramConfiguration
+        { Boundaries = MetricsCollector.CanonicalTimeBuckets })
     .AddPrometheusHttpListener(options =>
     {
         options.UriPrefixes = new[] { "http://*:9090/" };
     })
     .Build();
-
-// ... start the host ...
-
-// Dispose when shutting down.
-meterProvider?.Dispose();
 ```
-
-Metrics are now available at `http://localhost:9090/metrics` in Prometheus text format.
 
 ### Console Exporter (Development)
 
@@ -130,28 +145,31 @@ Monotonically increasing values. Prometheus exposes them with a `_total` suffix.
 
 | Name | Labels | Description |
 |---|---|---|
-| `task_poll_total` | `task_type` | Incremented once per poll round (regardless of how many tasks are returned). |
-| `task_poll_error_total` | `task_type`, `error_type` | Incremented when a poll HTTP call fails. `error_type` is the exception class name. |
-| `task_execute_error_total` | `task_type`, `error_type` | Incremented when `Execute()` throws. `error_type` is the exception class name. |
-| `task_update_error_total` | `task_type` | Incremented when all update retries are exhausted. |
-| `task_paused_total` | `task_type` | Incremented when a poll is skipped because the worker is paused. |
-| `task_execution_queue_full_total` | `task_type` | Incremented when a poll is skipped because all workers are busy (batch size reached). |
-| `thread_uncaught_exceptions_total` | -- | Incremented on any exception in the top-level poll loop that is not an `OperationCanceledException`. |
-| `workflow_start_error_total` | `workflow_type` | Incremented when a workflow start call fails. |
-| `external_payload_used_total` | `entity_name`, `operation`, `payload_type` | Incremented when external payload storage is used. |
+| `task_poll_total` | `taskType` | Incremented once per poll round (regardless of how many tasks are returned). |
+| `task_execution_started_total` | `taskType` | Incremented when a polled task is dispatched to the worker's `Execute()` method. |
+| `task_poll_error_total` | `taskType`, `exception` | Incremented when a poll HTTP call fails. `exception` is the exception class name. |
+| `task_execute_error_total` | `taskType`, `exception` | Incremented when `Execute()` throws. `exception` is the exception class name. |
+| `task_update_error_total` | `taskType`, `exception` | Incremented when all update retries are exhausted. `exception` is the exception class name. |
+| `task_ack_error_total` | `taskType`, `exception` | Surface-only: C# has no separate ack call (batch-poll response is the ack). Available for user code. |
+| `task_ack_failed_total` | `taskType` | Surface-only: same rationale as `task_ack_error_total`. |
+| `task_paused_total` | `taskType` | Incremented when a poll is skipped because the worker is paused. |
+| `task_execution_queue_full_total` | `taskType` | Incremented when a poll is skipped because all workers are busy (batch size reached). |
+| `thread_uncaught_exceptions_total` | `exception` | Incremented on any exception in the top-level poll loop that is not an `OperationCanceledException`. |
+| `workflow_start_error_total` | `workflowType`, `exception` | Incremented when a `WorkflowExecutor.StartWorkflow()` call fails. |
+| `external_payload_used_total` | `entityName`, `operation`, `payload_type` | Incremented when external payload storage is used. |
 
 ### Histograms
 
 Distribution metrics with sum, count, and bucket breakdowns. All time values are in **seconds**.
-All size values are in **bytes**.
 
 | Name | Labels | Unit | Description |
 |---|---|---|---|
-| `task_poll_time_seconds` | `task_type` | seconds | Wall-clock time for the poll HTTP call. |
-| `task_execute_time_seconds` | `task_type` | seconds | Wall-clock time inside `worker.Execute()`. |
-| `task_update_time_seconds` | `task_type` | seconds | Wall-clock time for the update call (including retries). |
-| `task_result_size_bytes` | `task_type` | bytes | JSON-serialized size of `TaskResult.OutputData`. |
-| `workflow_input_size_bytes` | `workflow_type`, `version` | bytes | Workflow input payload size. |
+| `task_poll_time_seconds` | `taskType`, `status` | seconds | Wall-clock time for the poll HTTP call. `status` is `SUCCESS` or `FAILURE`. |
+| `task_execute_time_seconds` | `taskType`, `status` | seconds | Wall-clock time inside `worker.Execute()`. `status` is `SUCCESS` or `FAILURE`. |
+| `task_update_time_seconds` | `taskType`, `status` | seconds | Wall-clock time for the update call (including retries). `status` is `SUCCESS` or `FAILURE`. |
+| `http_api_client_request_seconds` | `method`, `uri`, `status` | seconds | Every HTTP request made by the API client. `method` is the HTTP verb, `uri` is the request path, `status` is the HTTP status code (or `"0"` on transport failure). |
+| `task_result_size_bytes_histogram` | `taskType` | bytes | **[DEPRECATED]** JSON-serialized size of `TaskResult.OutputData`. Use the `task_result_size_bytes` Gauge instead. |
+| `workflow_input_size_bytes_histogram` | `workflowType`, `version` | bytes | **[DEPRECATED]** Workflow input payload size. Use the `workflow_input_size_bytes` Gauge instead. |
 
 ### Gauges
 
@@ -159,68 +177,114 @@ Point-in-time values sampled by the metrics listener.
 
 | Name | Labels | Description |
 |---|---|---|
-| `active_workers` | `task_type` | Number of concurrent task executions in progress. Updated on every poll cycle. |
+| `task_result_size_bytes` | `taskType` | Serialized byte size of the most recent task result output. Last-value gauge. |
+| `workflow_input_size_bytes` | `workflowType`, `version` | Serialized byte size of the most recent workflow input. Last-value gauge. |
+| `active_workers` | `taskType` | Number of concurrent task executions in progress. Updated on every poll cycle. |
 
 ## Labels
 
-| Label | Used By | Values |
+### Dual-Emit Strategy (Phase 1)
+
+As part of the cross-SDK metrics harmonization, every metric now emits **both** the canonical
+camelCase label and the legacy snake_case label with the same value. This ensures existing
+dashboards and alerts continue to work during migration.
+
+| Canonical (new) | Legacy (deprecated) | Used By |
 |---|---|---|
-| `task_type` | Most metrics | Task definition name (e.g. `"my_worker"`) |
-| `error_type` | `task_poll_error_total`, `task_execute_error_total` | Exception class name (e.g. `"HttpRequestException"`) |
-| `workflow_type` | `workflow_start_error_total`, `workflow_input_size_bytes` | Workflow definition name |
-| `version` | `workflow_input_size_bytes` | Workflow version string |
-| `entity_name` | `external_payload_used_total` | Entity name |
-| `operation` | `external_payload_used_total` | Operation name |
-| `payload_type` | `external_payload_used_total` | Payload type (e.g. `"TASK_INPUT"`, `"TASK_OUTPUT"`) |
+| `taskType` | `task_type` | Most task metrics |
+| `exception` | `error_type` | Error counters |
+| `workflowType` | `workflow_type` | Workflow metrics |
+| `entityName` | `entity_name` | `external_payload_used_total` |
+
+Labels that are new (no legacy equivalent): `status` on time histograms, `method`/`uri`/`status`
+on `http_api_client_request_seconds`, `version` on `workflow_input_size_bytes`.
+
+### Deprecated Labels
+
+The following labels are deprecated and will be removed in a future major release:
+
+- `task_type` — use `taskType`
+- `error_type` — use `exception`
+- `workflow_type` — use `workflowType`
+- `entity_name` — use `entityName`
+
+## Histogram Bucket Boundaries
+
+The SDK defines canonical bucket boundaries that match all other Conductor SDKs:
+
+**Time histograms** (`*_seconds`):
+
+```
+0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+```
+
+**Size histograms** (deprecated `*_histogram`):
+
+```
+100, 1000, 10000, 100000, 1000000, 10000000
+```
+
+These are applied automatically when using `MetricsCollector.StartServer(port)`. If you build
+your own `MeterProvider`, reference `MetricsCollector.CanonicalTimeBuckets` and
+`MetricsCollector.CanonicalSizeBuckets`.
 
 ## Example Metrics Output
 
-When scraped by Prometheus (via the OpenTelemetry exporter), the output looks like:
+When scraped by Prometheus (via the built-in server or OpenTelemetry exporter):
 
 ```prometheus
 # HELP task_poll_total Total task poll attempts
 # TYPE task_poll_total counter
-task_poll_total{task_type="my_worker"} 142
+task_poll_total{taskType="my_worker",task_type="my_worker"} 142
+
+# HELP task_execution_started_total Tasks dispatched to the worker function
+# TYPE task_execution_started_total counter
+task_execution_started_total{taskType="my_worker",task_type="my_worker"} 140
 
 # HELP task_poll_time_seconds Task poll round-trip duration (seconds)
 # TYPE task_poll_time_seconds histogram
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.005"} 12
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.01"} 45
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.025"} 98
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.05"} 120
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.1"} 135
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.25"} 140
-task_poll_time_seconds_bucket{task_type="my_worker",le="0.5"} 142
-task_poll_time_seconds_bucket{task_type="my_worker",le="1"} 142
-task_poll_time_seconds_bucket{task_type="my_worker",le="+Inf"} 142
-task_poll_time_seconds_sum{task_type="my_worker"} 3.842
-task_poll_time_seconds_count{task_type="my_worker"} 142
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.001"} 2
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.005"} 12
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.01"} 45
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.025"} 98
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.05"} 120
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.1"} 135
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.25"} 140
+task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="+Inf"} 140
+task_poll_time_seconds_sum{taskType="my_worker",task_type="my_worker",status="SUCCESS"} 3.842
+task_poll_time_seconds_count{taskType="my_worker",task_type="my_worker",status="SUCCESS"} 140
 
-# HELP task_execute_time_seconds Task execution duration (seconds)
-# TYPE task_execute_time_seconds histogram
-task_execute_time_seconds_bucket{task_type="my_worker",le="0.25"} 50
-task_execute_time_seconds_bucket{task_type="my_worker",le="0.5"} 80
-task_execute_time_seconds_bucket{task_type="my_worker",le="1"} 110
-task_execute_time_seconds_bucket{task_type="my_worker",le="2.5"} 135
-task_execute_time_seconds_bucket{task_type="my_worker",le="+Inf"} 142
-task_execute_time_seconds_sum{task_type="my_worker"} 98.553
-task_execute_time_seconds_count{task_type="my_worker"} 142
+# HELP http_api_client_request_seconds HTTP API client request duration (seconds)
+# TYPE http_api_client_request_seconds histogram
+http_api_client_request_seconds_bucket{method="GET",uri="/api/tasks/poll/batch/my_worker",status="200",le="0.01"} 30
+http_api_client_request_seconds_bucket{method="GET",uri="/api/tasks/poll/batch/my_worker",status="200",le="+Inf"} 142
+
+# HELP task_result_size_bytes Task result payload size (bytes)
+# TYPE task_result_size_bytes gauge
+task_result_size_bytes{taskType="my_worker",task_type="my_worker"} 2048
 
 # HELP active_workers Workers currently executing tasks
 # TYPE active_workers gauge
-active_workers{task_type="my_worker"} 5
+active_workers{taskType="my_worker",task_type="my_worker"} 5
 
 # HELP task_execution_queue_full_total Polls returning zero capacity
 # TYPE task_execution_queue_full_total counter
-task_execution_queue_full_total{task_type="my_worker"} 3
+task_execution_queue_full_total{taskType="my_worker",task_type="my_worker"} 3
 ```
+
+## OTel Scope Label
+
+The C# metrics output includes an `otel_scope_name="Conductor.Client"` label on every metric.
+This is injected by the OpenTelemetry .NET exporter (it identifies the `System.Diagnostics.Metrics.Meter`
+that owns each instrument). Other SDKs using native Prometheus client libraries do not have this.
+This is harmless — it is a standard OTel convention and does not interfere with canonical label queries.
 
 ## Best Practices
 
-1. **Use the OpenTelemetry Prometheus exporter for production.** It serves a standard `/metrics`
-   endpoint that Prometheus can scrape directly.
+1. **Use `MetricsCollector.StartServer(port)` for production.** It serves a standard `/metrics`
+   endpoint that Prometheus can scrape directly, with canonical bucket boundaries pre-configured.
 
-2. **Set histogram bucket boundaries via OpenTelemetry Views** if the defaults don't match your
+2. **Override histogram buckets via OpenTelemetry Views** if the defaults don't match your
    workload. For example, if your workers are consistently fast (< 100ms), add more fine-grained
    lower buckets:
    ```csharp
@@ -239,7 +303,7 @@ task_execution_queue_full_total{task_type="my_worker"} 3
 
 5. **Use `rate()` on counters, not raw values.** For example:
    ```promql
-   rate(task_poll_total{task_type="my_worker"}[5m])
+   rate(task_poll_total{taskType="my_worker"}[5m])
    ```
 
 6. **Track p99 execution latency** using histogram quantiles:
@@ -247,6 +311,10 @@ task_execution_queue_full_total{task_type="my_worker"} 3
    histogram_quantile(0.99, rate(task_execute_time_seconds_bucket[5m]))
    ```
 
-7. **The `MetricsCollector` is available as a singleton via DI.** You can inject it into your
-   own services to record `workflow_start_error_total`, `external_payload_used_total`, or any
-   other metrics that occur outside the poll loop.
+7. **Migrate dashboards to canonical labels.** Both `taskType` and `task_type` resolve to the
+   same value during Phase 1. Update your queries to use `taskType` before the deprecated labels
+   are removed in a future major release.
+
+8. **Use `WorkflowExecutor` for starting workflows.** It automatically records
+   `workflow_input_size_bytes` and `workflow_start_error_total` when a `MetricsCollector`
+   is injected.

--- a/Tests/Telemetry/MetricsCollectorTests.cs
+++ b/Tests/Telemetry/MetricsCollectorTests.cs
@@ -45,173 +45,299 @@ namespace Tests.Telemetry
             _listener.Start();
         }
 
-        public void Dispose() => _listener.Dispose();
+        public void Dispose()
+        {
+            _sut.Dispose();
+            _listener.Dispose();
+        }
 
         // ---------------------------------------------------------------
-        // Counters
+        // Counters — dual-emit label checks
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordTaskPoll_EmitsCounterWithTaskType()
+        public void RecordTaskPoll_EmitsDualLabels()
         {
             _sut.RecordTaskPoll("my_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_poll_total", m.Name);
             Assert.Equal(1L, m.Value);
+            AssertTag(m, "taskType", "my_task");
             AssertTag(m, "task_type", "my_task");
         }
 
         [Fact]
-        public void RecordTaskPollError_EmitsCounterWithBothTags()
+        public void RecordTaskExecutionStarted_EmitsDualLabels()
+        {
+            _sut.RecordTaskExecutionStarted("my_task");
+
+            var m = Assert.Single(_recorded);
+            Assert.Equal("task_execution_started_total", m.Name);
+            AssertTag(m, "taskType", "my_task");
+            AssertTag(m, "task_type", "my_task");
+        }
+
+        [Fact]
+        public void RecordTaskPollError_EmitsDualLabels()
         {
             _sut.RecordTaskPollError("my_task", "TimeoutException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_poll_error_total", m.Name);
+            AssertTag(m, "taskType", "my_task");
             AssertTag(m, "task_type", "my_task");
+            AssertTag(m, "exception", "TimeoutException");
             AssertTag(m, "error_type", "TimeoutException");
         }
 
         [Fact]
-        public void RecordTaskExecuteError_EmitsCounterWithBothTags()
+        public void RecordTaskExecuteError_EmitsDualLabels()
         {
             _sut.RecordTaskExecuteError("task_a", "NullReferenceException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execute_error_total", m.Name);
+            AssertTag(m, "taskType", "task_a");
             AssertTag(m, "task_type", "task_a");
+            AssertTag(m, "exception", "NullReferenceException");
             AssertTag(m, "error_type", "NullReferenceException");
         }
 
         [Fact]
-        public void RecordTaskUpdateError_EmitsCounter()
+        public void RecordTaskUpdateError_EmitsExceptionAndDualLabels()
         {
-            _sut.RecordTaskUpdateError("task_b");
+            _sut.RecordTaskUpdateError("task_b", "HttpRequestException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_update_error_total", m.Name);
+            AssertTag(m, "taskType", "task_b");
             AssertTag(m, "task_type", "task_b");
+            AssertTag(m, "exception", "HttpRequestException");
+            AssertTag(m, "error_type", "HttpRequestException");
         }
 
         [Fact]
-        public void RecordTaskPaused_EmitsCounter()
+        public void RecordTaskPaused_EmitsDualLabels()
         {
             _sut.RecordTaskPaused("paused_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_paused_total", m.Name);
+            AssertTag(m, "taskType", "paused_task");
             AssertTag(m, "task_type", "paused_task");
         }
 
         [Fact]
-        public void RecordTaskExecutionQueueFull_EmitsCounter()
+        public void RecordTaskExecutionQueueFull_EmitsDualLabels()
         {
             _sut.RecordTaskExecutionQueueFull("busy_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execution_queue_full_total", m.Name);
+            AssertTag(m, "taskType", "busy_task");
             AssertTag(m, "task_type", "busy_task");
         }
 
         [Fact]
-        public void RecordUncaughtException_EmitsCounterWithNoTags()
+        public void RecordUncaughtException_EmitsExceptionLabel()
         {
-            _sut.RecordUncaughtException();
+            _sut.RecordUncaughtException("InvalidOperationException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("thread_uncaught_exceptions_total", m.Name);
             Assert.Equal(1L, m.Value);
+            AssertTag(m, "exception", "InvalidOperationException");
         }
 
         [Fact]
-        public void RecordWorkflowStartError_EmitsCounter()
+        public void RecordWorkflowStartError_EmitsExceptionAndDualLabels()
         {
-            _sut.RecordWorkflowStartError("my_workflow");
+            _sut.RecordWorkflowStartError("my_workflow", "ApiException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("workflow_start_error_total", m.Name);
+            AssertTag(m, "workflowType", "my_workflow");
             AssertTag(m, "workflow_type", "my_workflow");
+            AssertTag(m, "exception", "ApiException");
         }
 
         [Fact]
-        public void RecordExternalPayloadUsed_EmitsCounterWithThreeTags()
+        public void RecordExternalPayloadUsed_EmitsDualLabels()
         {
-            _sut.RecordExternalPayloadUsed("entity", "read", "input");
+            _sut.RecordExternalPayloadUsed("entity", "READ", "TASK_INPUT");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("external_payload_used_total", m.Name);
+            AssertTag(m, "entityName", "entity");
             AssertTag(m, "entity_name", "entity");
-            AssertTag(m, "operation", "read");
-            AssertTag(m, "payload_type", "input");
+            AssertTag(m, "operation", "READ");
+            AssertTag(m, "payload_type", "TASK_INPUT");
+        }
+
+        [Fact]
+        public void RecordTaskAckError_EmitsDualLabels()
+        {
+            _sut.RecordTaskAckError("my_task", "HttpRequestException");
+
+            var m = Assert.Single(_recorded);
+            Assert.Equal("task_ack_error_total", m.Name);
+            AssertTag(m, "taskType", "my_task");
+            AssertTag(m, "task_type", "my_task");
+            AssertTag(m, "exception", "HttpRequestException");
+        }
+
+        [Fact]
+        public void RecordTaskAckFailed_EmitsDualLabels()
+        {
+            _sut.RecordTaskAckFailed("my_task");
+
+            var m = Assert.Single(_recorded);
+            Assert.Equal("task_ack_failed_total", m.Name);
+            AssertTag(m, "taskType", "my_task");
+            AssertTag(m, "task_type", "my_task");
         }
 
         // ---------------------------------------------------------------
-        // Histograms
+        // Histograms — status label
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordTaskPollTime_RecordsDuration()
+        public void RecordTaskPollTime_IncludesStatusLabel()
         {
-            _sut.RecordTaskPollTime("fast_task", 0.123);
+            _sut.RecordTaskPollTime("fast_task", 0.123, "SUCCESS");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_poll_time_seconds", m.Name);
             Assert.Equal(0.123, m.Value);
+            AssertTag(m, "taskType", "fast_task");
             AssertTag(m, "task_type", "fast_task");
+            AssertTag(m, "status", "SUCCESS");
         }
 
         [Fact]
-        public void RecordTaskExecuteTime_RecordsDuration()
+        public void RecordTaskExecuteTime_IncludesStatusLabel()
         {
-            _sut.RecordTaskExecuteTime("slow_task", 5.5);
+            _sut.RecordTaskExecuteTime("slow_task", 5.5, "FAILURE");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execute_time_seconds", m.Name);
             Assert.Equal(5.5, m.Value);
+            AssertTag(m, "taskType", "slow_task");
             AssertTag(m, "task_type", "slow_task");
+            AssertTag(m, "status", "FAILURE");
         }
 
         [Fact]
-        public void RecordTaskUpdateTime_RecordsDuration()
+        public void RecordTaskUpdateTime_IncludesStatusLabel()
         {
-            _sut.RecordTaskUpdateTime("task_c", 0.05);
+            _sut.RecordTaskUpdateTime("task_c", 0.05, "SUCCESS");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_update_time_seconds", m.Name);
             Assert.Equal(0.05, m.Value);
+            AssertTag(m, "taskType", "task_c");
             AssertTag(m, "task_type", "task_c");
+            AssertTag(m, "status", "SUCCESS");
         }
 
         [Fact]
-        public void RecordTaskResultSize_RecordsBytes()
+        public void RecordHttpApiClientRequest_RecordsDuration()
+        {
+            _sut.RecordHttpApiClientRequest("GET", "/api/tasks/poll/batch/my_task", "200", 0.042);
+
+            var m = Assert.Single(_recorded);
+            Assert.Equal("http_api_client_request_seconds", m.Name);
+            Assert.Equal(0.042, m.Value);
+            AssertTag(m, "method", "GET");
+            AssertTag(m, "uri", "/api/tasks/poll/batch/my_task");
+            AssertTag(m, "status", "200");
+        }
+
+        // ---------------------------------------------------------------
+        // Size metrics — gauge + deprecated histogram
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void RecordTaskResultSize_EmitsDeprecatedHistogram()
         {
             _sut.RecordTaskResultSize("task_d", 1024.0);
 
             var m = Assert.Single(_recorded);
-            Assert.Equal("task_result_size_bytes", m.Name);
+            Assert.Equal("task_result_size_bytes_histogram", m.Name);
             Assert.Equal(1024.0, m.Value);
+            AssertTag(m, "taskType", "task_d");
             AssertTag(m, "task_type", "task_d");
         }
 
         [Fact]
-        public void RecordWorkflowInputSize_RecordsBytesWithVersionTag()
+        public void RecordTaskResultSize_ExposedViaGauge()
         {
-            _sut.RecordWorkflowInputSize("wf_type", "v2", 2048.0);
+            _sut.RecordTaskResultSize("task_d", 2048.0);
+
+            var gaugeValues = new List<RecordedMeasurement>();
+            using var gaugeListener = new MeterListener();
+            gaugeListener.InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MetricsCollector.MeterName
+                    && instrument.Name == "task_result_size_bytes")
+                    l.EnableMeasurementEvents(instrument);
+            };
+            gaugeListener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                gaugeValues.Add(new RecordedMeasurement(instrument.Name, value, tags.ToArray())));
+            gaugeListener.Start();
+            gaugeListener.RecordObservableInstruments();
+
+            var match = Assert.Single(gaugeValues);
+            Assert.Equal(2048.0, (double)match.Value);
+            AssertTag(match, "taskType", "task_d");
+            AssertTag(match, "task_type", "task_d");
+        }
+
+        [Fact]
+        public void RecordWorkflowInputSize_EmitsDeprecatedHistogram()
+        {
+            _sut.RecordWorkflowInputSize("wf_type", "2", 2048.0);
 
             var m = Assert.Single(_recorded);
-            Assert.Equal("workflow_input_size_bytes", m.Name);
+            Assert.Equal("workflow_input_size_bytes_histogram", m.Name);
             Assert.Equal(2048.0, m.Value);
+            AssertTag(m, "workflowType", "wf_type");
             AssertTag(m, "workflow_type", "wf_type");
-            AssertTag(m, "version", "v2");
+            AssertTag(m, "version", "2");
+        }
+
+        [Fact]
+        public void RecordWorkflowInputSize_ExposedViaGauge()
+        {
+            _sut.RecordWorkflowInputSize("wf_type", "v2", 4096.0);
+
+            var gaugeValues = new List<RecordedMeasurement>();
+            using var gaugeListener = new MeterListener();
+            gaugeListener.InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MetricsCollector.MeterName
+                    && instrument.Name == "workflow_input_size_bytes")
+                    l.EnableMeasurementEvents(instrument);
+            };
+            gaugeListener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                gaugeValues.Add(new RecordedMeasurement(instrument.Name, value, tags.ToArray())));
+            gaugeListener.Start();
+            gaugeListener.RecordObservableInstruments();
+
+            var match = Assert.Single(gaugeValues);
+            Assert.Equal(4096.0, (double)match.Value);
+            AssertTag(match, "workflowType", "wf_type");
+            AssertTag(match, "workflow_type", "wf_type");
+            AssertTag(match, "version", "v2");
         }
 
         // ---------------------------------------------------------------
-        // Observable gauge
+        // Observable gauge — active_workers
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordActiveWorkers_ExposedViaObservableGauge()
+        public void RecordActiveWorkers_ExposedViaObservableGaugeWithDualLabels()
         {
             _sut.RecordActiveWorkers("task_x", 3);
             _sut.RecordActiveWorkers("task_y", 7);
@@ -231,9 +357,13 @@ namespace Tests.Telemetry
 
             Assert.Equal(2, gaugeValues.Count);
             Assert.Contains(gaugeValues, g =>
-                (int)g.Value == 3 && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_x"));
+                (int)g.Value == 3
+                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_x")
+                && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_x"));
             Assert.Contains(gaugeValues, g =>
-                (int)g.Value == 7 && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_y"));
+                (int)g.Value == 7
+                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_y")
+                && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_y"));
         }
 
         [Fact]
@@ -256,7 +386,7 @@ namespace Tests.Telemetry
             gaugeListener.RecordObservableInstruments();
 
             var match = gaugeValues.Where(g =>
-                g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "overwrite_test_task")).ToList();
+                g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "overwrite_test_task")).ToList();
             var single = Assert.Single(match);
             Assert.Equal(10, (int)single.Value);
         }
@@ -273,8 +403,26 @@ namespace Tests.Telemetry
             _sut.RecordTaskPoll("task_b");
 
             Assert.Equal(3, _recorded.Count);
-            Assert.Equal(2, _recorded.Count(r => r.Tags.Any(t => (string)t.Value == "task_a")));
-            Assert.Equal(1, _recorded.Count(r => r.Tags.Any(t => (string)t.Value == "task_b")));
+            Assert.Equal(2, _recorded.Count(r => r.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_a")));
+            Assert.Equal(1, _recorded.Count(r => r.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_b")));
+        }
+
+        // ---------------------------------------------------------------
+        // Canonical bucket constants
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void CanonicalTimeBuckets_MatchesSpec()
+        {
+            var expected = new double[] { 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 };
+            Assert.Equal(expected, MetricsCollector.CanonicalTimeBuckets);
+        }
+
+        [Fact]
+        public void CanonicalSizeBuckets_MatchesSpec()
+        {
+            var expected = new double[] { 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000 };
+            Assert.Equal(expected, MetricsCollector.CanonicalSizeBuckets);
         }
 
         // ---------------------------------------------------------------

--- a/Tests/Telemetry/MetricsCollectorTests.cs
+++ b/Tests/Telemetry/MetricsCollectorTests.cs
@@ -160,7 +160,7 @@ namespace Tests.Telemetry
             Assert.Equal("external_payload_used_total", m.Name);
             AssertTag(m, "entityName", "entity");
             AssertTag(m, "operation", "READ");
-            AssertTag(m, "payloadType", "TASK_INPUT");
+            AssertTag(m, "payload_type", "TASK_INPUT");
         }
 
         [Fact]

--- a/Tests/Telemetry/MetricsCollectorTests.cs
+++ b/Tests/Telemetry/MetricsCollectorTests.cs
@@ -52,11 +52,11 @@ namespace Tests.Telemetry
         }
 
         // ---------------------------------------------------------------
-        // Counters — dual-emit label checks
+        // Counters
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordTaskPoll_EmitsDualLabels()
+        public void RecordTaskPoll_EmitsCanonicalLabels()
         {
             _sut.RecordTaskPoll("my_task");
 
@@ -64,79 +64,69 @@ namespace Tests.Telemetry
             Assert.Equal("task_poll_total", m.Name);
             Assert.Equal(1L, m.Value);
             AssertTag(m, "taskType", "my_task");
-            AssertTag(m, "task_type", "my_task");
         }
 
         [Fact]
-        public void RecordTaskExecutionStarted_EmitsDualLabels()
+        public void RecordTaskExecutionStarted_EmitsCanonicalLabels()
         {
             _sut.RecordTaskExecutionStarted("my_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execution_started_total", m.Name);
             AssertTag(m, "taskType", "my_task");
-            AssertTag(m, "task_type", "my_task");
         }
 
         [Fact]
-        public void RecordTaskPollError_EmitsDualLabels()
+        public void RecordTaskPollError_EmitsCanonicalLabels()
         {
             _sut.RecordTaskPollError("my_task", "TimeoutException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_poll_error_total", m.Name);
             AssertTag(m, "taskType", "my_task");
-            AssertTag(m, "task_type", "my_task");
             AssertTag(m, "exception", "TimeoutException");
-            AssertTag(m, "error_type", "TimeoutException");
         }
 
         [Fact]
-        public void RecordTaskExecuteError_EmitsDualLabels()
+        public void RecordTaskExecuteError_EmitsCanonicalLabels()
         {
             _sut.RecordTaskExecuteError("task_a", "NullReferenceException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execute_error_total", m.Name);
             AssertTag(m, "taskType", "task_a");
-            AssertTag(m, "task_type", "task_a");
             AssertTag(m, "exception", "NullReferenceException");
-            AssertTag(m, "error_type", "NullReferenceException");
         }
 
         [Fact]
-        public void RecordTaskUpdateError_EmitsExceptionAndDualLabels()
+        public void RecordTaskUpdateError_EmitsCanonicalLabels()
         {
             _sut.RecordTaskUpdateError("task_b", "HttpRequestException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_update_error_total", m.Name);
             AssertTag(m, "taskType", "task_b");
-            AssertTag(m, "task_type", "task_b");
             AssertTag(m, "exception", "HttpRequestException");
-            AssertTag(m, "error_type", "HttpRequestException");
         }
 
         [Fact]
-        public void RecordTaskPaused_EmitsDualLabels()
+        public void RecordTaskPaused_EmitsCanonicalLabels()
         {
             _sut.RecordTaskPaused("paused_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_paused_total", m.Name);
             AssertTag(m, "taskType", "paused_task");
-            AssertTag(m, "task_type", "paused_task");
         }
 
         [Fact]
-        public void RecordTaskExecutionQueueFull_EmitsDualLabels()
+        public void RecordTaskExecutionQueueFull_EmitsCanonicalLabels()
         {
             _sut.RecordTaskExecutionQueueFull("busy_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_execution_queue_full_total", m.Name);
             AssertTag(m, "taskType", "busy_task");
-            AssertTag(m, "task_type", "busy_task");
         }
 
         [Fact]
@@ -151,51 +141,47 @@ namespace Tests.Telemetry
         }
 
         [Fact]
-        public void RecordWorkflowStartError_EmitsExceptionAndDualLabels()
+        public void RecordWorkflowStartError_EmitsCanonicalLabels()
         {
             _sut.RecordWorkflowStartError("my_workflow", "ApiException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("workflow_start_error_total", m.Name);
             AssertTag(m, "workflowType", "my_workflow");
-            AssertTag(m, "workflow_type", "my_workflow");
             AssertTag(m, "exception", "ApiException");
         }
 
         [Fact]
-        public void RecordExternalPayloadUsed_EmitsDualLabels()
+        public void RecordExternalPayloadUsed_EmitsCanonicalLabels()
         {
             _sut.RecordExternalPayloadUsed("entity", "READ", "TASK_INPUT");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("external_payload_used_total", m.Name);
             AssertTag(m, "entityName", "entity");
-            AssertTag(m, "entity_name", "entity");
             AssertTag(m, "operation", "READ");
-            AssertTag(m, "payload_type", "TASK_INPUT");
+            AssertTag(m, "payloadType", "TASK_INPUT");
         }
 
         [Fact]
-        public void RecordTaskAckError_EmitsDualLabels()
+        public void RecordTaskAckError_EmitsCanonicalLabels()
         {
             _sut.RecordTaskAckError("my_task", "HttpRequestException");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_ack_error_total", m.Name);
             AssertTag(m, "taskType", "my_task");
-            AssertTag(m, "task_type", "my_task");
             AssertTag(m, "exception", "HttpRequestException");
         }
 
         [Fact]
-        public void RecordTaskAckFailed_EmitsDualLabels()
+        public void RecordTaskAckFailed_EmitsCanonicalLabels()
         {
             _sut.RecordTaskAckFailed("my_task");
 
             var m = Assert.Single(_recorded);
             Assert.Equal("task_ack_failed_total", m.Name);
             AssertTag(m, "taskType", "my_task");
-            AssertTag(m, "task_type", "my_task");
         }
 
         // ---------------------------------------------------------------
@@ -211,7 +197,6 @@ namespace Tests.Telemetry
             Assert.Equal("task_poll_time_seconds", m.Name);
             Assert.Equal(0.123, m.Value);
             AssertTag(m, "taskType", "fast_task");
-            AssertTag(m, "task_type", "fast_task");
             AssertTag(m, "status", "SUCCESS");
         }
 
@@ -224,7 +209,6 @@ namespace Tests.Telemetry
             Assert.Equal("task_execute_time_seconds", m.Name);
             Assert.Equal(5.5, m.Value);
             AssertTag(m, "taskType", "slow_task");
-            AssertTag(m, "task_type", "slow_task");
             AssertTag(m, "status", "FAILURE");
         }
 
@@ -237,7 +221,6 @@ namespace Tests.Telemetry
             Assert.Equal("task_update_time_seconds", m.Name);
             Assert.Equal(0.05, m.Value);
             AssertTag(m, "taskType", "task_c");
-            AssertTag(m, "task_type", "task_c");
             AssertTag(m, "status", "SUCCESS");
         }
 
@@ -255,11 +238,11 @@ namespace Tests.Telemetry
         }
 
         // ---------------------------------------------------------------
-        // Size metrics — gauge + deprecated histogram
+        // Size metrics — gauge + histogram
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordTaskResultSize_EmitsDeprecatedHistogram()
+        public void RecordTaskResultSize_EmitsHistogram()
         {
             _sut.RecordTaskResultSize("task_d", 1024.0);
 
@@ -267,7 +250,6 @@ namespace Tests.Telemetry
             Assert.Equal("task_result_size_bytes_histogram", m.Name);
             Assert.Equal(1024.0, m.Value);
             AssertTag(m, "taskType", "task_d");
-            AssertTag(m, "task_type", "task_d");
         }
 
         [Fact]
@@ -291,11 +273,10 @@ namespace Tests.Telemetry
             var match = Assert.Single(gaugeValues);
             Assert.Equal(2048.0, (double)match.Value);
             AssertTag(match, "taskType", "task_d");
-            AssertTag(match, "task_type", "task_d");
         }
 
         [Fact]
-        public void RecordWorkflowInputSize_EmitsDeprecatedHistogram()
+        public void RecordWorkflowInputSize_EmitsHistogram()
         {
             _sut.RecordWorkflowInputSize("wf_type", "2", 2048.0);
 
@@ -303,7 +284,6 @@ namespace Tests.Telemetry
             Assert.Equal("workflow_input_size_bytes_histogram", m.Name);
             Assert.Equal(2048.0, m.Value);
             AssertTag(m, "workflowType", "wf_type");
-            AssertTag(m, "workflow_type", "wf_type");
             AssertTag(m, "version", "2");
         }
 
@@ -328,7 +308,6 @@ namespace Tests.Telemetry
             var match = Assert.Single(gaugeValues);
             Assert.Equal(4096.0, (double)match.Value);
             AssertTag(match, "workflowType", "wf_type");
-            AssertTag(match, "workflow_type", "wf_type");
             AssertTag(match, "version", "v2");
         }
 
@@ -337,7 +316,7 @@ namespace Tests.Telemetry
         // ---------------------------------------------------------------
 
         [Fact]
-        public void RecordActiveWorkers_ExposedViaObservableGaugeWithDualLabels()
+        public void RecordActiveWorkers_ExposedViaObservableGauge()
         {
             _sut.RecordActiveWorkers("task_x", 3);
             _sut.RecordActiveWorkers("task_y", 7);
@@ -358,12 +337,10 @@ namespace Tests.Telemetry
             Assert.Equal(2, gaugeValues.Count);
             Assert.Contains(gaugeValues, g =>
                 (int)g.Value == 3
-                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_x")
-                && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_x"));
+                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_x"));
             Assert.Contains(gaugeValues, g =>
                 (int)g.Value == 7
-                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_y")
-                && g.Tags.Any(t => t.Key == "task_type" && (string)t.Value == "task_y"));
+                && g.Tags.Any(t => t.Key == "taskType" && (string)t.Value == "task_y"));
         }
 
         [Fact]

--- a/Tests/Telemetry/MetricsCollectorTests.cs
+++ b/Tests/Telemetry/MetricsCollectorTests.cs
@@ -160,7 +160,7 @@ namespace Tests.Telemetry
             Assert.Equal("external_payload_used_total", m.Name);
             AssertTag(m, "entityName", "entity");
             AssertTag(m, "operation", "READ");
-            AssertTag(m, "payload_type", "TASK_INPUT");
+            AssertTag(m, "payloadType", "TASK_INPUT");
         }
 
         [Fact]

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,8 +17,7 @@ compatible with any .NET metrics listener -- most notably the
   - [Histograms](#histograms)
   - [Gauges](#gauges)
 - [Labels](#labels)
-  - [Dual-Emit Strategy (Phase 1)](#dual-emit-strategy-phase-1)
-  - [Deprecated Labels](#deprecated-labels)
+- [Nonstandard Metrics](#nonstandard-metrics)
 - [Histogram Bucket Boundaries](#histogram-bucket-boundaries)
 - [Example Metrics Output](#example-metrics-output)
 - [OTel Scope Label](#otel-scope-label)
@@ -28,29 +27,29 @@ compatible with any .NET metrics listener -- most notably the
 
 All metrics are registered under the meter named `Conductor.Client`.
 
-| Name | Type | Canonical Labels | Deprecated Labels | Description |
-|---|---|---|---|---|
-| `task_poll_total` | Counter | `taskType` | `task_type` | Total task poll attempts |
-| `task_execution_started_total` | Counter | `taskType` | `task_type` | Tasks dispatched to the worker function |
-| `task_poll_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task poll errors |
-| `task_execute_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task execution errors |
-| `task_update_error_total` | Counter | `taskType`, `exception` | `task_type`, `error_type` | Total task update errors (after all retries) |
-| `task_ack_error_total` | Counter | `taskType`, `exception` | `task_type` | Task ack client-side errors (surface-only) |
-| `task_ack_failed_total` | Counter | `taskType` | `task_type` | Task ack declined by server (surface-only) |
-| `task_paused_total` | Counter | `taskType` | `task_type` | Polls skipped because the worker is paused |
-| `task_execution_queue_full_total` | Counter | `taskType` | `task_type` | Polls returning zero capacity (all workers busy) |
-| `thread_uncaught_exceptions_total` | Counter | `exception` | -- | Uncaught exceptions in worker threads |
-| `workflow_start_error_total` | Counter | `workflowType`, `exception` | `workflow_type` | Errors starting workflows |
-| `external_payload_used_total` | Counter | `entityName`, `operation`, `payload_type` | `entity_name` | External payload storage usage |
-| `task_poll_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task poll round-trip duration (seconds) |
-| `task_execute_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task execution duration (seconds) |
-| `task_update_time_seconds` | Histogram | `taskType`, `status` | `task_type` | Task result update duration (seconds) |
-| `http_api_client_request_seconds` | Histogram | `method`, `uri`, `status` | -- | HTTP API client request duration (seconds) |
-| `task_result_size_bytes` | **Gauge** | `taskType` | `task_type` | Task result payload size (bytes) — last value |
-| `task_result_size_bytes_histogram` | Histogram | `taskType` | `task_type` | **[DEPRECATED]** Task result payload size (bytes) |
-| `workflow_input_size_bytes` | **Gauge** | `workflowType`, `version` | `workflow_type` | Workflow input payload size (bytes) — last value |
-| `workflow_input_size_bytes_histogram` | Histogram | `workflowType`, `version` | `workflow_type` | **[DEPRECATED]** Workflow input payload size (bytes) |
-| `active_workers` | Gauge | `taskType` | `task_type` | Workers currently executing tasks |
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `task_poll_total` | Counter | `taskType` | Total task poll attempts |
+| `task_execution_started_total` | Counter | `taskType` | Tasks dispatched to the worker function |
+| `task_poll_error_total` | Counter | `taskType`, `exception` | Total task poll errors |
+| `task_execute_error_total` | Counter | `taskType`, `exception` | Total task execution errors |
+| `task_update_error_total` | Counter | `taskType`, `exception` | Total task update errors (after all retries) |
+| `task_ack_error_total` | Counter | `taskType`, `exception` | Task ack client-side errors (surface-only) |
+| `task_ack_failed_total` | Counter | `taskType` | Task ack declined by server (surface-only) |
+| `task_paused_total` | Counter | `taskType` | Polls skipped because the worker is paused |
+| `task_execution_queue_full_total` | Counter | `taskType` | Polls returning zero capacity (all workers busy) |
+| `thread_uncaught_exceptions_total` | Counter | `exception` | Uncaught exceptions in worker threads |
+| `workflow_start_error_total` | Counter | `workflowType`, `exception` | Errors starting workflows |
+| `external_payload_used_total` | Counter | `entityName`, `operation`, `payload_type` | External payload storage usage |
+| `task_poll_time_seconds` | Histogram | `taskType`, `status` | Task poll round-trip duration (seconds) |
+| `task_execute_time_seconds` | Histogram | `taskType`, `status` | Task execution duration (seconds) |
+| `task_update_time_seconds` | Histogram | `taskType`, `status` | Task result update duration (seconds) |
+| `http_api_client_request_seconds` | Histogram | `method`, `uri`, `status` | HTTP API client request duration (seconds) |
+| `task_result_size_bytes` | Gauge | `taskType` | Task result payload size (bytes) — last value |
+| `workflow_input_size_bytes` | Gauge | `workflowType`, `version` | Workflow input payload size (bytes) — last value |
+| `active_workers` | Gauge | `taskType` | Workers currently executing tasks |
+| `task_result_size_bytes_histogram` | Histogram | `taskType` | Task result payload size (bytes) — **nonstandard**, see [below](#nonstandard-metrics) |
+| `workflow_input_size_bytes_histogram` | Histogram | `workflowType`, `version` | Workflow input payload size (bytes) — **nonstandard**, see [below](#nonstandard-metrics) |
 
 ## Configuration
 
@@ -168,8 +167,6 @@ Distribution metrics with sum, count, and bucket breakdowns. All time values are
 | `task_execute_time_seconds` | `taskType`, `status` | seconds | Wall-clock time inside `worker.Execute()`. `status` is `SUCCESS` or `FAILURE`. |
 | `task_update_time_seconds` | `taskType`, `status` | seconds | Wall-clock time for the update call (including retries). `status` is `SUCCESS` or `FAILURE`. |
 | `http_api_client_request_seconds` | `method`, `uri`, `status` | seconds | Every HTTP request made by the API client. `method` is the HTTP verb, `uri` is the request path, `status` is the HTTP status code (or `"0"` on transport failure). |
-| `task_result_size_bytes_histogram` | `taskType` | bytes | **[DEPRECATED]** JSON-serialized size of `TaskResult.OutputData`. Use the `task_result_size_bytes` Gauge instead. |
-| `workflow_input_size_bytes_histogram` | `workflowType`, `version` | bytes | **[DEPRECATED]** Workflow input payload size. Use the `workflow_input_size_bytes` Gauge instead. |
 
 ### Gauges
 
@@ -183,30 +180,53 @@ Point-in-time values sampled by the metrics listener.
 
 ## Labels
 
-### Dual-Emit Strategy (Phase 1)
+The C# SDK uses the canonical label names defined by the cross-SDK metrics harmonization spec.
 
-As part of the cross-SDK metrics harmonization, every metric now emits **both** the canonical
-camelCase label and the legacy snake_case label with the same value. This ensures existing
-dashboards and alerts continue to work during migration.
-
-| Canonical (new) | Legacy (deprecated) | Used By |
+| Label | Used by | Values |
 |---|---|---|
-| `taskType` | `task_type` | Most task metrics |
-| `exception` | `error_type` | Error counters |
-| `workflowType` | `workflow_type` | Workflow metrics |
-| `entityName` | `entity_name` | `external_payload_used_total` |
+| `taskType` | Most task metrics | The task definition name (e.g. `my_worker`). |
+| `workflowType` | Workflow metrics | The workflow definition name. |
+| `entityName` | `external_payload_used_total` | The entity identifier. |
+| `exception` | Error counters, `thread_uncaught_exceptions_total` | The .NET exception class name (e.g. `HttpRequestException`). |
+| `status` | Time histograms | `SUCCESS` or `FAILURE`. |
+| `method` | `http_api_client_request_seconds` | HTTP verb (`GET`, `POST`, etc.). |
+| `uri` | `http_api_client_request_seconds` | Request path (interpolated, not templated). |
+| `operation` | `external_payload_used_total` | `READ` or `WRITE`. |
+| `payload_type` | `external_payload_used_total` | `TASK_INPUT`, `TASK_OUTPUT`, `WORKFLOW_INPUT`, or `WORKFLOW_OUTPUT`. |
+| `version` | `workflow_input_size_bytes` | Workflow version string. |
 
-Labels that are new (no legacy equivalent): `status` on time histograms, `method`/`uri`/`status`
-on `http_api_client_request_seconds`, `version` on `workflow_input_size_bytes`.
+**Label naming convention.** Labels referencing Conductor domain entities (`taskType`,
+`workflowType`, `entityName`) use camelCase to match the Conductor API's JSON field names.
+Generic observability labels (`status`, `method`, `uri`, `exception`, `operation`,
+`payload_type`, `version`) follow the standard Prometheus snake_case / lowercase convention.
 
-### Deprecated Labels
+> **Note:** Unlike some other Conductor SDKs that are undergoing a migration from legacy
+> label names, the C# SDK's metrics surface is entirely new and emits only canonical labels.
+> There are no legacy/deprecated label aliases.
 
-The following labels are deprecated and will be removed in a future major release:
+## Nonstandard Metrics
 
-- `task_type` — use `taskType`
-- `error_type` — use `exception`
-- `workflow_type` — use `workflowType`
-- `entity_name` — use `entityName`
+The C# SDK emits two additional **histogram** instruments for payload sizes that are not part
+of the cross-SDK canonical catalog:
+
+| Name | Labels | Unit | Description |
+|---|---|---|---|
+| `task_result_size_bytes_histogram` | `taskType` | bytes | Distribution of task result payload sizes. |
+| `workflow_input_size_bytes_histogram` | `workflowType`, `version` | bytes | Distribution of workflow input payload sizes. |
+
+The canonical catalog defines size metrics as **last-value Gauges** (`task_result_size_bytes`,
+`workflow_input_size_bytes`), which is what the SDK emits as its primary size instruments.
+These histogram variants provide distribution information (bucket breakdowns, count, sum) that
+the gauge shape cannot offer -- for example, computing p99 result sizes via
+`histogram_quantile()`.
+
+These histograms are **proposed** for inclusion in a future revision of the canonical catalog
+(see the harmonization spec's §5.1 "Future catalog considerations"). They use the proposed
+size bucket set `(100, 1000, 10000, 100000, 1000000, 10000000)` bytes. Until the catalog
+formally adopts them, they should be considered nonstandard and may change.
+
+Both are emitted automatically whenever the corresponding gauge is recorded (i.e. calling
+`RecordTaskResultSize` writes to both the gauge and the histogram).
 
 ## Histogram Bucket Boundaries
 
@@ -218,7 +238,7 @@ The SDK defines canonical bucket boundaries that match all other Conductor SDKs:
 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
 ```
 
-**Size histograms** (deprecated `*_histogram`):
+**Size histograms** (nonstandard `*_histogram`, proposed):
 
 ```
 100, 1000, 10000, 100000, 1000000, 10000000
@@ -235,24 +255,24 @@ When scraped by Prometheus (via the built-in server or OpenTelemetry exporter):
 ```prometheus
 # HELP task_poll_total Total task poll attempts
 # TYPE task_poll_total counter
-task_poll_total{taskType="my_worker",task_type="my_worker"} 142
+task_poll_total{taskType="my_worker"} 142
 
 # HELP task_execution_started_total Tasks dispatched to the worker function
 # TYPE task_execution_started_total counter
-task_execution_started_total{taskType="my_worker",task_type="my_worker"} 140
+task_execution_started_total{taskType="my_worker"} 140
 
 # HELP task_poll_time_seconds Task poll round-trip duration (seconds)
 # TYPE task_poll_time_seconds histogram
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.001"} 2
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.005"} 12
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.01"} 45
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.025"} 98
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.05"} 120
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.1"} 135
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="0.25"} 140
-task_poll_time_seconds_bucket{taskType="my_worker",task_type="my_worker",status="SUCCESS",le="+Inf"} 140
-task_poll_time_seconds_sum{taskType="my_worker",task_type="my_worker",status="SUCCESS"} 3.842
-task_poll_time_seconds_count{taskType="my_worker",task_type="my_worker",status="SUCCESS"} 140
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.001"} 2
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.005"} 12
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.01"} 45
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.025"} 98
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.05"} 120
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.1"} 135
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="0.25"} 140
+task_poll_time_seconds_bucket{taskType="my_worker",status="SUCCESS",le="+Inf"} 140
+task_poll_time_seconds_sum{taskType="my_worker",status="SUCCESS"} 3.842
+task_poll_time_seconds_count{taskType="my_worker",status="SUCCESS"} 140
 
 # HELP http_api_client_request_seconds HTTP API client request duration (seconds)
 # TYPE http_api_client_request_seconds histogram
@@ -261,15 +281,15 @@ http_api_client_request_seconds_bucket{method="GET",uri="/api/tasks/poll/batch/m
 
 # HELP task_result_size_bytes Task result payload size (bytes)
 # TYPE task_result_size_bytes gauge
-task_result_size_bytes{taskType="my_worker",task_type="my_worker"} 2048
+task_result_size_bytes{taskType="my_worker"} 2048
 
 # HELP active_workers Workers currently executing tasks
 # TYPE active_workers gauge
-active_workers{taskType="my_worker",task_type="my_worker"} 5
+active_workers{taskType="my_worker"} 5
 
 # HELP task_execution_queue_full_total Polls returning zero capacity
 # TYPE task_execution_queue_full_total counter
-task_execution_queue_full_total{taskType="my_worker",task_type="my_worker"} 3
+task_execution_queue_full_total{taskType="my_worker"} 3
 ```
 
 ## OTel Scope Label
@@ -277,7 +297,7 @@ task_execution_queue_full_total{taskType="my_worker",task_type="my_worker"} 3
 The C# metrics output includes an `otel_scope_name="Conductor.Client"` label on every metric.
 This is injected by the OpenTelemetry .NET exporter (it identifies the `System.Diagnostics.Metrics.Meter`
 that owns each instrument). Other SDKs using native Prometheus client libraries do not have this.
-This is harmless — it is a standard OTel convention and does not interfere with canonical label queries.
+This is harmless — it is a standard OTel convention and does not interfere with label queries.
 
 ## Best Practices
 
@@ -311,10 +331,6 @@ This is harmless — it is a standard OTel convention and does not interfere wit
    histogram_quantile(0.99, rate(task_execute_time_seconds_bucket[5m]))
    ```
 
-7. **Migrate dashboards to canonical labels.** Both `taskType` and `task_type` resolve to the
-   same value during Phase 1. Update your queries to use `taskType` before the deprecated labels
-   are removed in a future major release.
-
-8. **Use `WorkflowExecutor` for starting workflows.** It automatically records
+7. **Use `WorkflowExecutor` for starting workflows.** It automatically records
    `workflow_input_size_bytes` and `workflow_start_error_total` when a `MetricsCollector`
    is injected.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -40,7 +40,7 @@ All metrics are registered under the meter named `Conductor.Client`.
 | `task_execution_queue_full_total` | Counter | `taskType` | Polls returning zero capacity (all workers busy) |
 | `thread_uncaught_exceptions_total` | Counter | `exception` | Uncaught exceptions in worker threads |
 | `workflow_start_error_total` | Counter | `workflowType`, `exception` | Errors starting workflows |
-| `external_payload_used_total` | Counter | `entityName`, `operation`, `payload_type` | External payload storage usage |
+| `external_payload_used_total` | Counter | `entityName`, `operation`, `payloadType` | External payload storage usage |
 | `task_poll_time_seconds` | Histogram | `taskType`, `status` | Task poll round-trip duration (seconds) |
 | `task_execute_time_seconds` | Histogram | `taskType`, `status` | Task execution duration (seconds) |
 | `task_update_time_seconds` | Histogram | `taskType`, `status` | Task result update duration (seconds) |
@@ -155,7 +155,7 @@ Monotonically increasing values. Prometheus exposes them with a `_total` suffix.
 | `task_execution_queue_full_total` | `taskType` | Incremented when a poll is skipped because all workers are busy (batch size reached). |
 | `thread_uncaught_exceptions_total` | `exception` | Incremented on any exception in the top-level poll loop that is not an `OperationCanceledException`. |
 | `workflow_start_error_total` | `workflowType`, `exception` | Incremented when a `WorkflowExecutor.StartWorkflow()` call fails. |
-| `external_payload_used_total` | `entityName`, `operation`, `payload_type` | Incremented when external payload storage is used. |
+| `external_payload_used_total` | `entityName`, `operation`, `payloadType` | Incremented when external payload storage is used. |
 
 ### Histograms
 
@@ -192,13 +192,14 @@ The C# SDK uses the canonical label names defined by the cross-SDK metrics harmo
 | `method` | `http_api_client_request_seconds` | HTTP verb (`GET`, `POST`, etc.). |
 | `uri` | `http_api_client_request_seconds` | Request path (interpolated, not templated). |
 | `operation` | `external_payload_used_total` | `READ` or `WRITE`. |
-| `payload_type` | `external_payload_used_total` | `TASK_INPUT`, `TASK_OUTPUT`, `WORKFLOW_INPUT`, or `WORKFLOW_OUTPUT`. |
+| `payloadType` | `external_payload_used_total` | `TASK_INPUT`, `TASK_OUTPUT`, `WORKFLOW_INPUT`, or `WORKFLOW_OUTPUT`. |
 | `version` | `workflow_input_size_bytes` | Workflow version string. |
 
 **Label naming convention.** Labels referencing Conductor domain entities (`taskType`,
 `workflowType`, `entityName`) use camelCase to match the Conductor API's JSON field names.
 Generic observability labels (`status`, `method`, `uri`, `exception`, `operation`,
-`payload_type`, `version`) follow the standard Prometheus snake_case / lowercase convention.
+`version`) follow the standard Prometheus snake_case / lowercase convention.
+`payloadType` uses camelCase to match other Conductor domain-entity labels.
 
 > **Note:** Unlike some other Conductor SDKs that are undergoing a migration from legacy
 > label names, the C# SDK's metrics surface is entirely new and emits only canonical labels.

--- a/docs/readme/workers.md
+++ b/docs/readme/workers.md
@@ -50,19 +50,8 @@ Thread.Sleep(TimeSpan.FromSeconds(100));
 
 Check out our [integration tests](https://github.com/conductor-sdk/conductor-csharp/blob/92c7580156a89322717c94aeaea9e5201fe577eb/Tests/Worker/WorkerTests.cs#L37) for more examples
 
-Worker SDK collects the following metrics:
-
-
-| Name               | Purpose                                      | Tags                             |
-| ------------------ | :------------------------------------------- | -------------------------------- |
-| task_poll_error    | Client error when polling for a task queue   | taskType, includeRetries, status |
-| task_execute_error | Execution error                              | taskType                         |
-| task_update_error  | Task status cannot be updated back to server | taskType                         |
-| task_poll_counter  | Incremented each time polling is done        | taskType                         |
-| task_poll_time     | Time to poll for a batch of tasks            | taskType                         |
-| task_execute_time  | Time to execute a task                       | taskType                         |
-| task_result_size   | Records output payload size of a task        | taskType                         |
-
-Metrics on client side supplements the one collected from server in identifying the network as well as client side issues.
+The worker SDK collects metrics for poll latency, execution time, update time, error rates, queue
+utilization, and more. See [metrics.md](../metrics.md) for the full list of metrics, labels,
+configuration options, and example Prometheus output.
 
 ### Next: [Create and Execute Workflows](https://github.com/conductor-sdk/conductor-csharp/blob/main/docs/readme/workflow.md)


### PR DESCRIPTION
This SDK was lacking metrics, and having metrics from each SDK is part of requirements for certification cluster deployments. This initial implementation is in alignment with the sdk metrics standardization proposal that has been documented at https://orkes.atlassian.net/browse/TOOL-34 - with the addition of proposed input/output size histograms (currently canonically as guages).

The set of canonical metrics has been uncovered by doing a full audit of the existing SDKs metrics production and trying to synthesize it all into something sensible.