### PR TITLE
fix: skip token exchange when no credentials configured (OSS Conductor auth)

### DIFF
--- a/Conductor/Client/Authentication/TokenHandler.cs
+++ b/Conductor/Client/Authentication/TokenHandler.cs
@@ -33,6 +33,14 @@ namespace Conductor.Client.Authentication
 
         public string GetToken(OrkesAuthenticationSettings authenticationSettings, TokenResourceApi tokenClient)
         {
+            // OSS Conductor: if no credentials are configured, skip token exchange entirely.
+            if (authenticationSettings == null ||
+                string.IsNullOrEmpty(authenticationSettings.KeyId) ||
+                string.IsNullOrEmpty(authenticationSettings.KeySecret))
+            {
+                return null;
+            }
+
             string token = (string)_memoryCache.Get(authenticationSettings);
             if (token != null)
             {
@@ -43,6 +51,14 @@ namespace Conductor.Client.Authentication
 
         public string RefreshToken(OrkesAuthenticationSettings authenticationSettings, TokenResourceApi tokenClient)
         {
+            // OSS Conductor: if no credentials are configured, skip token exchange entirely.
+            if (authenticationSettings == null ||
+                string.IsNullOrEmpty(authenticationSettings.KeyId) ||
+                string.IsNullOrEmpty(authenticationSettings.KeySecret))
+            {
+                return null;
+            }
+
             lock (_lockObject)
             {
                 string token = GetTokenFromServer(authenticationSettings, tokenClient);


### PR DESCRIPTION
## Problem

When `OrkesAuthenticationSettings` is not configured (null `KeyId`/`KeySecret`), accessing `Configuration.AccessToken` calls `TokenHandler.GetToken()` which unconditionally proceeds to `POST /api/token`. On OSS Conductor this endpoint returns 404/405, causing an unhandled exception and preventing the SDK from being used against unauthenticated OSS deployments at all.

## Fix

Added early-return guards in both `GetToken()` and `RefreshToken()` in `TokenHandler.cs`: if `authenticationSettings` is null or either `KeyId`/`KeySecret` is null or empty, return `null` immediately without attempting the token exchange.

This is safe because:
- If auth is not configured, the caller should not expect a token.
- The existing `Configuration.AccessToken` property already returns `null` when `AuthenticationSettings is null`, so downstream code already handles `null` tokens.
- Authenticated (Orkes Cloud) deployments are unaffected — they always provide non-empty credentials.

## Changes

`Conductor/Client/Authentication/TokenHandler.cs`
- `GetToken()`: return `null` early when credentials are absent
- `RefreshToken()`: return `null` early when credentials are absent

## Testing

To reproduce the bug before this fix: create a `Configuration` with no `AuthenticationSettings`, call any API method, observe the `404`/`405` exception from `TokenHandler`. After this fix the call proceeds without a token (appropriate for OSS Conductor).
