### PR TITLE
fix: async void -> async Task and fix TotalMilliseconds in Sleep log

### DIFF
--- a/Conductor/Client/Worker/WorkflowTaskExecutor.cs
+++ b/Conductor/Client/Worker/WorkflowTaskExecutor.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2024 Conductor Authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -93,7 +93,7 @@ namespace Conductor.Client.Worker
                     if (token != CancellationToken.None)
                         token.ThrowIfCancellationRequested();
 
-                    WorkOnce(token);
+                    WorkOnce(token).GetAwaiter().GetResult();
                 }
                 catch (System.OperationCanceledException canceledException)
                 {
@@ -120,7 +120,7 @@ namespace Conductor.Client.Worker
             }
         }
 
-        private async void WorkOnce(CancellationToken token)
+        private async System.Threading.Tasks.Task WorkOnce(CancellationToken token)
         {
             if (token != CancellationToken.None)
                 token.ThrowIfCancellationRequested();
@@ -201,7 +201,7 @@ namespace Conductor.Client.Worker
             }
         }
 
-        private async void ProcessTasks(List<Models.Task> tasks, CancellationToken token)
+        private async System.Threading.Tasks.Task ProcessTasks(List<Models.Task> tasks, CancellationToken token)
         {
             List<System.Threading.Tasks.Task> threads = new List<System.Threading.Tasks.Task>();
             if (tasks == null || tasks.Count == 0)
@@ -221,7 +221,7 @@ namespace Conductor.Client.Worker
             await System.Threading.Tasks.Task.WhenAll(threads);
         }
 
-        private async void ProcessTask(Models.Task task, CancellationToken token)
+        private async System.Threading.Tasks.Task ProcessTask(Models.Task task, CancellationToken token)
         {
             if (token != CancellationToken.None)
                 token.ThrowIfCancellationRequested();
@@ -341,7 +341,7 @@ namespace Conductor.Client.Worker
 
         private void Sleep(TimeSpan timeSpan)
         {
-            _logger.LogDebug($"[{_workerSettings.WorkerId}] Sleeping for {timeSpan.Milliseconds}ms");
+            _logger.LogDebug($"[{_workerSettings.WorkerId}] Sleeping for {timeSpan.TotalMilliseconds}ms");
             Thread.Sleep(timeSpan);
         }
 


### PR DESCRIPTION
## Problems Fixed

### Bug 2: `async void` fire-and-forget in WorkflowTaskExecutor

`WorkOnce`, `ProcessTasks`, and `ProcessTask` were all declared `private async void`. This means:
- Exceptions thrown inside these methods are never caught by the `Work4Ever` try/catch loop.
- The caller cannot await them, so task processing silently swallows errors.

**Fix:** Changed all three to `private async Task`. `Work4Ever` now calls `WorkOnce(token).GetAwaiter().GetResult()` to preserve the synchronous outer loop while surfacing exceptions correctly.

### Bug 3: `TimeSpan.Milliseconds` vs `TimeSpan.TotalMilliseconds` in Sleep log

The `Sleep()` helper logged `timeSpan.Milliseconds`, which is the sub-second milliseconds component (range 0-999). Any sleep of 1 second or more would log an incorrect/truncated value (e.g., a 1.5s sleep logs `500ms`, a 2s sleep logs `0ms`).

**Fix:** Changed to `timeSpan.TotalMilliseconds` which returns the full duration as a double.

## Changes

`Conductor/Client/Worker/WorkflowTaskExecutor.cs`
- `WorkOnce`: `async void` -> `async Task`
- `ProcessTasks`: `async void` -> `async Task`
- `ProcessTask`: `async void` -> `async Task`
- `Work4Ever`: awaits `WorkOnce` via `.GetAwaiter().GetResult()`
- `Sleep()`: log uses `timeSpan.TotalMilliseconds` instead of `timeSpan.Milliseconds`
